### PR TITLE
RFC: First version of conditional block

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Cond.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Cond.java
@@ -1,0 +1,51 @@
+package nl.utwente.group10.haskell.expr;
+
+import nl.utwente.group10.haskell.env.Env;
+import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.hindley.GenSet;
+import nl.utwente.group10.haskell.hindley.HindleyMilner;
+import nl.utwente.group10.haskell.type.ConstT;
+import nl.utwente.group10.haskell.type.Type;
+
+public class Cond extends Expr {
+    private Expr condition;
+    private Expr trueCase;
+    private Expr falseCase;
+
+    public final String TPL = "(if %s then %s else %s)";
+
+    public Cond(Expr condition, Expr trueCase, Expr falseCase) {
+        this.condition = condition;
+        this.trueCase = trueCase;
+        this.falseCase = falseCase;
+    }
+
+    @Override
+    public Type analyze(Env env, GenSet genSet) throws HaskellException {
+        final Type condType = condition.analyze(env, genSet);
+        final Type trueType = trueCase.analyze(env, genSet);
+        final Type falseType = falseCase.analyze(env, genSet);
+        final Type resType = HindleyMilner.makeVariable();
+
+        // Condition must be a boolean
+        HindleyMilner.unify(this, condType, new ConstT("Bool"));
+
+        // Branches must have compatible types
+        HindleyMilner.unify(this, trueType, falseType);
+
+        // Figure out the result type
+        HindleyMilner.unify(this, trueType, resType);
+
+        return resType;
+    }
+
+    @Override
+    public String toHaskell() {
+        return String.format(TPL, condition.toHaskell(), trueCase.toHaskell(), falseCase.toHaskell());
+    }
+
+    @Override
+    public String toString() {
+        return String.format(TPL, condition, trueCase, falseCase);
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/Main.java
@@ -13,6 +13,7 @@ import nl.utwente.group10.ghcj.GhciEvaluator;
 import nl.utwente.group10.ghcj.GhciException;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.ui.components.CustomAlert;
+import nl.utwente.group10.ui.components.blocks.CondBlock;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
 import nl.utwente.group10.ui.components.blocks.ValueBlock;
 import nl.utwente.group10.ui.menu.MainMenu;
@@ -42,7 +43,8 @@ public class Main extends Application {
 
         ValueBlock valueBlock = new ValueBlock(tactilePane);
         DisplayBlock displayBlock = new DisplayBlock(tactilePane);
-        tactilePane.getChildren().addAll(valueBlock, displayBlock);
+        CondBlock condBlock = new CondBlock(tactilePane);
+        tactilePane.getChildren().addAll(valueBlock, displayBlock, condBlock);
 
         // Init Debug
         DebugParent debug = new DebugParent(tactilePane);
@@ -77,6 +79,7 @@ public class Main extends Application {
 
         valueBlock.relocate(tactilePane.getWidth() / 2, tactilePane.getHeight() / 2);
         displayBlock.relocate(tactilePane.getWidth() / 2, tactilePane.getHeight() / 2 + 100);
+        condBlock.relocate(tactilePane.getWidth() / 2, tactilePane.getHeight() / 2 + 200);
 
         // Invalidate
         tactilePane.invalidateAll();

--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -34,7 +34,7 @@ public class OutputAnchor extends ConnectionAnchor {
     @Override
     public Type getType() {
         if (getBlock() instanceof OutputBlock) {
-            return ((OutputBlock) getBlock()).getOutputType();
+            return ((OutputBlock) getBlock()).getOutputType(getPane().getEnvInstance());
         } else {
             throw new TypeUnavailableException();
         }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/CondBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/CondBlock.java
@@ -1,0 +1,116 @@
+package nl.utwente.group10.ui.components.blocks;
+
+import com.google.common.collect.ImmutableList;
+import javafx.fxml.FXML;
+import javafx.scene.layout.Pane;
+import nl.utwente.group10.haskell.env.Env;
+import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.expr.Cond;
+import nl.utwente.group10.haskell.expr.Expr;
+import nl.utwente.group10.haskell.hindley.HindleyMilner;
+import nl.utwente.group10.haskell.type.ConstT;
+import nl.utwente.group10.haskell.type.Type;
+import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.components.anchors.InputAnchor;
+import nl.utwente.group10.ui.components.anchors.OutputAnchor;
+
+import java.util.List;
+
+public class CondBlock extends Block implements InputBlock, OutputBlock {
+    @FXML private Pane anchorSpace;
+    @FXML private Pane outputSpace;
+
+    private InputAnchor cond, t, f;
+    private OutputAnchor out;
+
+    public CondBlock(CustomUIPane parent) {
+        super(parent);
+        loadFXML("CondBlock");
+
+        cond = new InputAnchor(this, parent);
+        t = new InputAnchor(this, parent);
+        f = new InputAnchor(this, parent);
+
+        out = new OutputAnchor(this, parent);
+
+        anchorSpace.getChildren().setAll(cond, t, f);
+        outputSpace.getChildren().setAll(out);
+    }
+
+    @Override
+    public Expr asExpr() {
+        return new Cond(cond.asExpr(), t.asExpr(), f.asExpr());
+    }
+
+    /* CondBlock-specific code ends here. */
+
+    @Override
+    public Type getInputSignature(InputAnchor input) {
+        if (input.equals(cond)) return new ConstT("Bool");
+        else return HindleyMilner.makeVariable();
+    }
+
+    @Override
+    public Type getInputSignature(int index) {
+        if (index == 0) return new ConstT("Bool");
+        else return HindleyMilner.makeVariable();
+    }
+
+    @Override
+    public Type getInputType(InputAnchor input) {
+        // TODO not sure what to return here
+        return HindleyMilner.makeVariable();
+    }
+
+    @Override
+    public Type getInputType(int index) {
+        // TODO not sure what to return here
+        return HindleyMilner.makeVariable();
+    }
+
+    @Override
+    public List<InputAnchor> getAllInputs() {
+        return ImmutableList.of(cond, t, f);
+    }
+
+    @Override
+    public List<InputAnchor> getActiveInputs() {
+        // TODO Not that useful, can't partially apply an if
+        return getAllInputs();
+    }
+
+    @Override
+    public OutputAnchor getOutputAnchor() {
+        return out;
+    }
+
+    @Override
+    public Type getOutputType() {
+        // TODO do we need to support this?
+        return getOutputType(new Env());
+    }
+
+    @Override
+    public Type getOutputType(Env env) {
+        // TODO not sure if this is the right place to call analyze()
+
+        try {
+            return asExpr().analyze(env).prune();
+        } catch (HaskellException e) {
+            return getOutputSignature();
+        }
+    }
+
+
+    @Override
+    public Type getOutputSignature() {
+        // TODO not sure what to return here
+        return HindleyMilner.makeVariable();
+    }
+
+    @Override
+    public Type getOutputSignature(Env env) {
+        // TODO not sure what to return here
+        return HindleyMilner.makeVariable();
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/menu/MainMenu.java
@@ -13,6 +13,7 @@ import nl.utwente.group10.haskell.catalog.FunctionEntry;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.components.blocks.CondBlock;
 import nl.utwente.group10.ui.components.blocks.ValueBlock;
 import nl.utwente.group10.ui.components.blocks.DisplayBlock;
 import nl.utwente.group10.ui.components.blocks.FunctionBlock;
@@ -45,6 +46,8 @@ public class MainMenu extends ContextMenu {
         valueBlockItem.setOnAction(event -> addBlock(new ValueBlock(parent)));
         MenuItem displayBlockItem = new MenuItem("Display Block");
         displayBlockItem.setOnAction(event -> addBlock(new DisplayBlock(parent)));
+        MenuItem conditionBlockItem = new MenuItem("Condition Block");
+        conditionBlockItem.setOnAction(event -> addBlock(new CondBlock(parent)));
 
         // TODO remove this item when debugging of visualFeedback is done
         MenuItem errorItem = new MenuItem("Error all Blocks");
@@ -55,7 +58,7 @@ public class MainMenu extends ContextMenu {
 
         SeparatorMenuItem sep = new SeparatorMenuItem();
 
-        this.getItems().addAll(valueBlockItem, displayBlockItem, sep, errorItem, quitItem);
+        this.getItems().addAll(valueBlockItem, displayBlockItem, conditionBlockItem, sep, errorItem, quitItem);
     }
 
     private void addFunctionBlock(FunctionEntry entry) {

--- a/Code/src/main/resources/catalog/catalog.xml
+++ b/Code/src/main/resources/catalog/catalog.xml
@@ -118,5 +118,12 @@
                 Undefined function.
             </function>
         </category>
+        <category name="Boolean logic">
+            <function name="True" signature="Bool" />
+            <function name="False" signature="Bool" />
+            <function name="(&amp;&amp;)" signature="Bool -> Bool -> Bool" />
+            <function name="(||)" signature="Bool -> Bool -> Bool" />
+            <function name="not" signature="Bool -> Bool" />
+        </category>
     </functions>
 </catalog>

--- a/Code/src/main/resources/ui/CondBlock.fxml
+++ b/Code/src/main/resources/ui/CondBlock.fxml
@@ -1,0 +1,22 @@
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.FlowPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<fx:root type="nl.utwente.group10.ui.components.blocks.CondBlock" xmlns:fx="http://javafx.com/fxml/1">
+    <BorderPane>
+        <top>
+            <FlowPane fx:id="anchorSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="CENTER" />
+        </top>
+        <center>
+            <HBox styleClass="cond, block" alignment="CENTER">
+                <padding><Insets top="5" right="10" bottom="5" left="10"/></padding>
+                <Label styleClass="title">if</Label>
+            </HBox>
+        </center>
+        <bottom>
+            <VBox fx:id="outputSpace" alignment="CENTER" />
+        </bottom>
+    </BorderPane>
+</fx:root>

--- a/Code/src/main/resources/ui/style.css
+++ b/Code/src/main/resources/ui/style.css
@@ -61,6 +61,10 @@ CustomUIPane {
     -fx-background-color: #c0392b;
 }
 
+.cond.block {
+    -fx-background-color: #27ae60;
+}
+
 .value.block .title, .display.block .title {
 
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/CondTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/CondTest.java
@@ -1,0 +1,75 @@
+package nl.utwente.group10.haskell.expr;
+
+import nl.utwente.group10.haskell.env.Env;
+import nl.utwente.group10.haskell.exceptions.HaskellException;
+import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
+import nl.utwente.group10.haskell.hindley.GenSet;
+import nl.utwente.group10.haskell.hindley.HindleyMilner;
+import nl.utwente.group10.haskell.type.ConstT;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CondTest {
+    private Env env;
+    private GenSet genSet;
+
+    @Before
+    public final void setUp() {
+        this.env = new Env();
+        this.env.addExpr("undefined", "a");
+
+        this.genSet = new GenSet();
+    }
+
+    @Test(expected=HaskellTypeError.class)
+    public final void testNonBool() throws HaskellException {
+        Expr expr = new Cond(
+            new Value(new ConstT("Float"), "1.0"),
+            new Ident("undefined"),
+            new Ident("undefined")
+        );
+
+        expr.analyze(env, genSet);
+    }
+
+    @Test(expected=HaskellTypeError.class)
+    public final void testIncompatible() throws HaskellException {
+        Expr expr = new Cond(
+            new Value(new ConstT("Bool"), "True"),
+            new Value(new ConstT("A"), "foo"),
+            new Value(new ConstT("B"), "bar")
+        );
+
+        expr.analyze(env, genSet);
+    }
+
+    @Test
+    public final void testValid() throws HaskellException {
+        Expr expr = new Cond(
+            new Value(new ConstT("Bool"), "True"),
+            new Value(new ConstT("Float"), "1.0"),
+            new Value(new ConstT("Float"), "2.0")
+        );
+
+        Assert.assertEquals("Float", expr.analyze(env, genSet).prune().toHaskellType());
+    }
+
+    @Test
+    public final void testInfer() throws HaskellException {
+        Expr one = new Cond(
+                new Value(new ConstT("Bool"), "True"),
+                new Value(HindleyMilner.makeVariable(), "1.0"),
+                new Value(new ConstT("Float"), "2.0")
+        );
+
+        Expr two = new Cond(
+                new Value(new ConstT("Bool"), "True"),
+                new Value(new ConstT("Float"), "2.0"),
+                new Value(HindleyMilner.makeVariable(), "1.0")
+        );
+
+        Assert.assertEquals("Float", one.analyze(env, genSet).prune().toHaskellType());
+        Assert.assertEquals("Float", two.analyze(env, genSet).prune().toHaskellType());
+    }
+}


### PR DESCRIPTION
The conditional block is a visual representation of the if-then-else construct
in Haskell: if the Bool in the first anchor evaluates to True, the result is
the expression of the second anchor, else the result comes from the third
anchor. Of course, the types of the second and third anchors have to unify.

This first version already has working asExpr and type inference on the backend
(see tests), but I'm not sure I implemented InputBlock/OutputBlock correctly -
type checking on the frontend doesn't seem to work like I expect it to. This
could be related to #87.

I haven't thought about how the thing should look; comments are more than
welcome.