### PR TITLE
Let Expr cache expressions

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -38,8 +38,8 @@ public class Apply extends Expr {
 
     @Override
     public final Type analyze(final Env env, final GenSet genSet) throws HaskellException {
-        final Type funcType = func.analyze(env, genSet);
-        final Type argType = arg.analyze(env, genSet);
+        final Type funcType = func.getType(env);
+        final Type argType = arg.getType(env);
         final Type resType = HindleyMilner.makeVariable();
 
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -48,6 +48,8 @@ public class Apply extends Expr {
         // THEN the type of our result is b
         HindleyMilner.unify(this, funcType, new FuncT(argType, resType));
 
+        this.setCachedType(resType);
+
         return resType;
     }
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -38,8 +38,8 @@ public class Apply extends Expr {
 
     @Override
     public final Type analyze(final Env env, final GenSet genSet) throws HaskellException {
-        final Type funcType = func.getType(env);
-        final Type argType = arg.getType(env);
+        final Type funcType = func.analyze(env, genSet);
+        final Type argType = arg.analyze(env, genSet);
         final Type resType = HindleyMilner.makeVariable();
 
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
@@ -1,6 +1,7 @@
 package nl.utwente.group10.haskell.expr;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import com.google.common.collect.ImmutableList;
@@ -16,6 +17,25 @@ import nl.utwente.group10.haskell.type.Type;
 public abstract class Expr extends HaskellObject {
     /** Logger for this class. **/
     protected static final Logger logger = Logger.getLogger(Expr.class.getName());
+
+    /** The last known type for this expression. */
+    private Optional<Type> cachedType = Optional.empty();
+
+    /**
+     * Returns the latest type for this expression. If {@code analayze()} has not been called yet, it will be called to
+     * retrieve a type.
+     *
+     * @param env The current Haskell environment.
+     * @return The type for this usage of this expression.
+     * @throws HaskellException The type tree contains an application of an incompatible type.
+     */
+    public Type getType(Env env) throws HaskellException {
+        if (!this.cachedType.isPresent()) {
+            this.cachedType = Optional.of(this.analyze(env));
+        }
+
+        return this.cachedType.get();
+    }
 
     /**
      * Analyzes the type tree and resolves the type for this usage of this expression.

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
@@ -42,7 +42,9 @@ public abstract class Expr extends HaskellObject {
      * @param type The type to cache.
      */
     protected final void setCachedType(final Type type) {
-        this.cachedType = Optional.ofNullable(type);
+        if (!this.cachedType.isPresent() || this.cachedType.get() != type) {
+            this.cachedType = Optional.ofNullable(type);
+        }
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
@@ -31,10 +31,18 @@ public abstract class Expr extends HaskellObject {
      */
     public Type getType(Env env) throws HaskellException {
         if (!this.cachedType.isPresent()) {
-            this.cachedType = Optional.of(this.analyze(env));
+            return this.analyze(env);
         }
 
         return this.cachedType.get();
+    }
+
+    /**
+     * Sets the cached type for this expression.
+     * @param type The type to cache.
+     */
+    protected final void setCachedType(final Type type) {
+        this.cachedType = Optional.ofNullable(type);
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
@@ -74,10 +74,10 @@ public class Function extends Expr {
 
     @Override
     public Type analyze(Env env, GenSet genSet) throws HaskellException {
-        Type type = this.expr.analyze(env).prune().getFresh();
+        Type type = this.expr.getType(env).prune().getFresh();
 
         for (int i = this.arguments.size(); i > 0; i--) {
-            type = new FuncT(this.arguments.get(i - 1).analyze(env).getFresh(), type);
+            type = new FuncT(this.arguments.get(i - 1).getType(env).getFresh(), type);
         }
 
         this.setCachedType(type);

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
@@ -74,10 +74,10 @@ public class Function extends Expr {
 
     @Override
     public Type analyze(Env env, GenSet genSet) throws HaskellException {
-        Type type = this.expr.getType(env).prune().getFresh();
+        Type type = this.expr.analyze(env).prune().getFresh();
 
         for (int i = this.arguments.size(); i > 0; i--) {
-            type = new FuncT(this.arguments.get(i - 1).getType(env).getFresh(), type);
+            type = new FuncT(this.arguments.get(i - 1).analyze(env).getFresh(), type);
         }
 
         this.setCachedType(type);

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
@@ -80,6 +80,8 @@ public class Function extends Expr {
             type = new FuncT(this.arguments.get(i - 1).analyze(env).getFresh(), type);
         }
 
+        this.setCachedType(type);
+
         return type;
     }
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Ident.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Ident.java
@@ -32,8 +32,10 @@ public class Ident extends Expr {
         // THEN the type of this expr is x.
         Optional<Type> type = env.getFreshExprType(this.name);
         if (type.isPresent()) {
+            this.setCachedType(type.get());
             return type.get();
         } else {
+            this.setCachedType(null);
             Expr.logger.warning(String.format("Expression %s is not in the environment, but it is assumed to be.", this));
             throw new HaskellException("Expression not in environment", this);
         }

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Value.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Value.java
@@ -28,6 +28,7 @@ public class Value extends Expr {
     public Value(final Type type, final String value) {
         this.type = type;
         this.value = value;
+        setCachedType(this.type);
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
@@ -70,9 +70,8 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
     private void walk(TreeItem<String> treeItem, Expr expr) {
         String type;
 
-        // TODO: Would rather *not* call analyze here as analyze is destructive
         try {
-            type = expr.analyze(pane.getEnvInstance()).prune().toHaskellType();
+            type = expr.getType(pane.getEnvInstance()).prune().toHaskellType();
         } catch (HaskellException e) {
             type = "?";
         }

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
@@ -1,8 +1,5 @@
 package nl.utwente.group10.haskell.expr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
@@ -11,6 +8,8 @@ import nl.utwente.group10.haskell.type.*;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class ExprTest {
     private final Type alpha = new VarT("a");
@@ -53,6 +52,15 @@ public class ExprTest {
     @Test
     public final void testAnalyze() throws HaskellException {
         assertEquals("[(Int -> Int)]", this.expr.analyze(this.env, this.genSet).prune().toHaskellType());
+    }
+
+    @Test
+    public final void testGetType() throws HaskellException {
+        Type type = this.expr.getType(this.env);
+
+        // Test is object is equal after subsequent call and not equal to the result of analyze
+        assertTrue(type == this.expr.getType(env));
+        assertFalse(type == this.expr.analyze(env));
     }
 
     @Test(expected = HaskellTypeError.class)

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
@@ -60,7 +60,7 @@ public class ExprTest {
 
         // Test is object is equal after subsequent call and not equal to the result of analyze
         assertTrue(type == this.expr.getType(env));
-        assertFalse(type == this.expr.analyze(env));
+        assertFalse(this.expr instanceof Value || type == this.expr.analyze(env)); // Only valid for non-Value exprs.
     }
 
     @Test(expected = HaskellTypeError.class)


### PR DESCRIPTION
Part of #112.

Also fixes InspectorWindow to not (possibly) modify types when UI calls type checker correctly.