### PR TITLE
Simplify InputBlock/OutputBlock interfaces

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/anchors/OutputAnchor.java
@@ -34,7 +34,7 @@ public class OutputAnchor extends ConnectionAnchor {
     @Override
     public Type getType() {
         if (getBlock() instanceof OutputBlock) {
-            return ((OutputBlock) getBlock()).getOutputType();
+            return ((OutputBlock) getBlock()).getOutputType(this.getPane().getEnvInstance());
         } else {
             throw new TypeUnavailableException();
         }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/DisplayBlock.java
@@ -107,43 +107,19 @@ public class DisplayBlock extends Block implements InputBlock {
         if(anchor.getPrimaryOppositeAnchor().isPresent()) {
             return anchor.getPrimaryOppositeAnchor().get().getType();
         } else {
-            return getInputSignature();
+            return getInputSignature(anchor);
         }
     }
 
-    private Type getInputSignature() {
+    @Override
+    public Type getInputSignature(InputAnchor anchor) {
         // Return the type 'a', that matches anything.
         // In the future this should probably be changed to '(Show a)'
         return HindleyMilner.makeVariable();
     }
 
     @Override
-    public Type getInputSignature(InputAnchor input) {
-        return getInputSignature();
-    }
-
-    @Override
-    public Type getInputSignature(int index) {
-        return getInputSignature();
-    }
-
-    @Override
-    public Type getInputType(int index) {
-        return getInputSignature();
-    }
-
-    @Override
     public List<InputAnchor> getAllInputs() {
         return ImmutableList.of(inputAnchor);
-    }
-
-    @Override
-    public List<InputAnchor> getActiveInputs() {
-        return getAllInputs();
-    }
-
-    @Override
-    public int getInputIndex(InputAnchor anchor) {
-        return 0;
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/FunctionBlock.java
@@ -266,11 +266,6 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
     
     @Override
-    public Type getOutputSignature() {
-        return getOutputSignature(getPane().getEnvInstance());
-    }
-
-    @Override
     public Type getOutputSignature(Env env) {
         Type type = getFunctionSignature();
         for (int i = 0; i < getBowtieIndex(); i++) {
@@ -284,16 +279,11 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     }
 
     @Override
-    public Type getOutputType() {
-        return getOutputType(getPane().getEnvInstance());
-    }
-
-    @Override
     public Type getOutputType(Env env) {
         try {
             return asExpr().analyze(env).prune();
         } catch (HaskellException e) {
-            return getOutputSignature();
+            return getOutputSignature(env);
         }
     }
 
@@ -342,7 +332,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
      */
     private void invalidateOutputVisuals() {
         Label outputLabel = ((Label) argumentSpace.getChildren().get(argumentSpace.getChildren().size() - 1));
-        outputLabel.setText(getOutputType().toHaskellType());
+        outputLabel.setText(getOutputType(getPane().getEnvInstance()).toHaskellType());
     }
 
     /**
@@ -366,7 +356,7 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
         super.setError(error);
     }
     
-    private final void setInputError(int index, boolean error) {
+    private void setInputError(int index, boolean error) {
         ObservableList<String> styleClass = argumentSpace.getChildren().get(index).getStyleClass();
         if (error) {
             styleClass.removeAll("error");

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/GraphBlock.java
@@ -65,22 +65,7 @@ public class GraphBlock extends Block implements InputBlock {
     }
 
     @Override
-    public Type getInputType(InputAnchor input) {
-        return getInputSignature(0);
-    }
-
-    @Override
-    public Type getInputType(int index) {
-        return getInputSignature(0);
-    }
-
-    @Override
     public List<InputAnchor> getAllInputs() {
-        return ImmutableList.of(input);
-    }
-
-    @Override
-    public List<InputAnchor> getActiveInputs() {
         return ImmutableList.of(input);
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/InputBlock.java
@@ -2,6 +2,7 @@ package nl.utwente.group10.ui.components.blocks;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.ui.components.anchors.InputAnchor;
 
@@ -23,26 +24,36 @@ public interface InputBlock {
      */
     Type getInputSignature(InputAnchor input);
 
-    Type getInputSignature(int index);
+    default Type getInputSignature(int index) {
+        return getInputSignature(getAllInputs().get(index));
+    }
 
     /**
      * @param input
      *            The argument of which the type is desired.
      * @return The current type given to the specified input argument.
      */
-    Type getInputType(InputAnchor input);
+    default Type getInputType(InputAnchor input) {
+        return getInputSignature(input);
+    }
 
-    Type getInputType(int index);
+    default Type getInputType(int index) {
+        return getInputSignature(index);
+    }
 
     /**
      * @return All inputs of the block.
      */
-    List<InputAnchor> getAllInputs();
+    default List<InputAnchor> getAllInputs() {
+        return ImmutableList.of();
+    }
 
     /**
      * @return Only the active (as specified with the bowtie) inputs.
      */
-    List<InputAnchor> getActiveInputs();
+    default List<InputAnchor> getActiveInputs() {
+        return getAllInputs();
+    }
 
     /**
      * @return The index the specified anchor has (in getInputs())

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/OutputBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/OutputBlock.java
@@ -9,7 +9,7 @@ public interface OutputBlock {
     /**
      * @return the output Anchor for this Block
      */
-    public OutputAnchor getOutputAnchor();
+    OutputAnchor getOutputAnchor();
 
     /*
      * Signature = non unified type, ie: a->b
@@ -24,14 +24,12 @@ public interface OutputBlock {
     /**
      * @return The current output type of the block.
      */
-    Type getOutputType();
-
-    Type getOutputType(Env env);
+    default Type getOutputType(Env env) {
+        return getOutputSignature(env);
+    }
 
     /**
      * @return The output type as specified by the function's signature.
      */
-    Type getOutputSignature();
-
     Type getOutputSignature(Env env);
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/ValueBlock.java
@@ -81,21 +81,6 @@ public class ValueBlock extends Block implements OutputBlock {
     }
 
     @Override
-    public Type getOutputType() {
-        return getOutputType(getPane().getEnvInstance());
-    }
-
-    @Override
-    public Type getOutputType(Env env) {
-        return getOutputSignature(env);
-    }
-
-    @Override
-    public Type getOutputSignature() {
-        return getOutputSignature(getPane().getEnvInstance());
-    }
-
-    @Override
     public Type getOutputSignature(Env env) {
         try {
             return asExpr().analyze(env);


### PR DESCRIPTION
Not all implementations of all methods of the InputBlock/OutputBlock are very interesting. This commit introduces some reasonable default implementations of InputBlock/OutputBlock methods and removes some superfluous ones.