### PR TITLE
HM: Union typeclasses instead of intersecting them

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -1,5 +1,7 @@
 package nl.utwente.group10.haskell.type;
 
+import com.google.common.collect.Sets;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
@@ -73,19 +75,7 @@ public class VarT extends Type {
      * @return Whether the given type is within the constraints of this type.
      */
     public final boolean hasConstraint(Type type) {
-        boolean out = false;
-
-        if (!this.constraints.isEmpty()) {
-            for (TypeClass typeclass : this.constraints) {
-                if (typeclass.hasType(type)) {
-                    out = true;
-                }
-            }
-        } else {
-            out = true;
-        }
-
-        return out;
+        return constraints.stream().allMatch(tc -> tc.hasType(type));
     }
 
     /**
@@ -150,29 +140,8 @@ public class VarT extends Type {
         return this.instance.isPresent() ? String.format("%s:%s", this.name, this.instance.get()) : this.name;
     }
 
-    /**
-     * Calculates the intersection of two VarT constraints and returns the set of matching type classes.
-     * @param a The first type.
-     * @param b The second type.
-     * @return The set of type classes that are in both types.
-     */
-    public static Set<TypeClass> intersect(VarT a, VarT b) {
-        //TODO: TEMPORARY WORKAROUND
-        if (!a.hasConstraints()) return b.constraints;
-        if (!b.hasConstraints()) return a.constraints;
-        
-        final Set<TypeClass> intersection = new HashSet<TypeClass>();
-
-        if (!a.hasConstraints()) {
-            intersection.addAll(b.constraints);
-        } else if (!b.hasConstraints()) {
-            intersection.addAll(a.constraints);
-        } else {
-            intersection.addAll(a.constraints);
-            intersection.retainAll(b.constraints);
-        }
-
-        return intersection;
+    public static Set<TypeClass> union(VarT a, VarT b) {
+        return Sets.union(a.constraints, b.constraints);
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -140,6 +140,7 @@ public class VarT extends Type {
         return this.instance.isPresent() ? String.format("%s:%s", this.name, this.instance.get()) : this.name;
     }
 
+    /** Return the set of typeclasses that is the union of both arguments' constraints. */
     public static Set<TypeClass> union(VarT a, VarT b) {
         return Sets.union(a.constraints, b.constraints);
     }

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -1,6 +1,8 @@
 package nl.utwente.group10.haskell.type;
 
 import static org.junit.Assert.*;
+
+import com.google.common.collect.ImmutableSet;
 import nl.utwente.group10.haskell.catalog.HaskellCatalog;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.CatalogException;
@@ -12,6 +14,8 @@ import nl.utwente.group10.haskell.expr.Value;
 import nl.utwente.group10.haskell.hindley.HindleyMilner;
 
 import org.junit.Test;
+
+import java.util.HashSet;
 
 public class ApplyTest {
     @Test
@@ -49,19 +53,19 @@ public class ApplyTest {
         
         Expr e1 = new Ident("undefined");
         Type t1 = e1.analyze(env).prune();
-        HindleyMilner.unify(t1, new Value(new ConstT("Float"), "5.0").analyze(env));
+        HindleyMilner.unify(t1, new ConstT("Float"));
         // t1 Should unfiy with everything (the type of t1 should be 'a').
         // No exception thrown -> Types are the same, as expected. The test will
         // fail if an Exception is thrown.
         
-        
         Expr e2 = new Apply(e0, e1);
         Type t2 = e2.analyze(env).prune();
-        assertEquals("(a -> a)", t2.toHaskellType());
+        Type num = HindleyMilner.makeVariable(ImmutableSet.of(env.getTypeClasses().get("Num")));
+        HindleyMilner.unify(t2, new FuncT(num, num));
         
         Expr e3 = new Apply(e2, new Ident("undefined"));
         Type t3 = e3.analyze(env).prune();
-        HindleyMilner.unify(t3, new Value(new ConstT("Float"), "5.0").analyze(env));
+        HindleyMilner.unify(t3, new ConstT("Float"));
         // t3 Should unfiy with everything (the type of t3 should be 'a').
         // No exception thrown -> Types are the same, as expected. The test will
         // fail if an Exception is thrown.

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
@@ -73,4 +73,25 @@ public class UnificationTest {
         
         HindleyMilner.unify(t2, t4);
     }
+
+    @Test
+    public void testTypeclassCopy() throws HaskellException {
+        Env env = new HaskellCatalog().asEnvironment();
+        TypeClass num = env.getTypeClasses().get("Num");
+        TypeClass read = env.getTypeClasses().get("Show");
+        TypeClass show = env.getTypeClasses().get("Read");
+
+        Type ct = new ConstT("Float");
+        Type t0 = new VarT("a", num, read);
+        Type t1 = new VarT("b", num, show);
+
+        Expr e0 = new Value(t0, "?");
+        Expr e1 = new Value(t1, "?");
+        Expr e2 = new Apply(new Apply(new Ident("(+)"), e0), e1);
+
+        e2.analyze(env);
+
+        HindleyMilner.unify(t0, ct);
+        HindleyMilner.unify(t1, ct);
+    }
 }


### PR DESCRIPTION
I distinctly remember claiming that, when one unifies two variable types
that both have typeclasses, one should take the intersection of their
respective constraints.

This is, of course, patent nonsense. If you have two functions:

    f :: (Show a, Fruit a) => a -> a
    f x = x

    g :: (Show b, Vehicle b) => b -> b
    g y = y

And you define a third function:

    h z = (f z, g z)

Then z must be Show, Fruit *and* Vehicle (a banana mobile, perhaps?)
GHCi will gladly give you the actual signature:

    h :: (Show t, Vehicle t, Fruit t) => t -> (t, t)

In other words, the sets of constraints are unioned, not intersected,
with one another. This commit is a first attempt at that.