### PR TITLE
Typecheck cleanup

### DIFF
--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -39,7 +39,7 @@ public class Apply extends Expr {
     public final Type analyze(final Env env) throws HaskellException {
         final Type funcType = func.analyze(env);
         final Type argType = arg.analyze(env);
-        final Type resType = TypeChecker.makeVariable();
+        final Type resType = TypeChecker.makeVariable("b");
 
 
         // Rule [App]:

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -3,8 +3,8 @@ package nl.utwente.group10.haskell.expr;
 import com.google.common.collect.ImmutableList;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 import nl.utwente.group10.haskell.type.FuncT;
+import nl.utwente.group10.haskell.type.TypeChecker;
 import nl.utwente.group10.haskell.type.Type;
 
 import java.util.List;
@@ -39,13 +39,13 @@ public class Apply extends Expr {
     public final Type analyze(final Env env) throws HaskellException {
         final Type funcType = func.analyze(env);
         final Type argType = arg.analyze(env);
-        final Type resType = HindleyMilner.makeVariable();
+        final Type resType = TypeChecker.makeVariable();
 
 
         // Rule [App]:
         // IFF  the type of our function is a -> b and the type of our arg is a
         // THEN the type of our result is b
-        HindleyMilner.unify(this, funcType, new FuncT(argType, resType));
+        TypeChecker.unify(this, funcType, new FuncT(argType, resType));
 
         this.setCachedType(resType);
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Apply.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.haskell.expr;
 import com.google.common.collect.ImmutableList;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.hindley.HindleyMilner;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
@@ -37,9 +36,9 @@ public class Apply extends Expr {
     }
 
     @Override
-    public final Type analyze(final Env env, final GenSet genSet) throws HaskellException {
-        final Type funcType = func.analyze(env, genSet);
-        final Type argType = arg.analyze(env, genSet);
+    public final Type analyze(final Env env) throws HaskellException {
+        final Type funcType = func.analyze(env);
+        final Type argType = arg.analyze(env);
         final Type resType = HindleyMilner.makeVariable();
 
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Expr.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableList;
 import nl.utwente.group10.haskell.HaskellObject;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.Type;
 
 /**
@@ -48,16 +47,6 @@ public abstract class Expr extends HaskellObject {
     }
 
     /**
-     * Analyzes the type tree and resolves the type for this usage of this expression.
-     *
-     * @param env The current Haskell environment.
-     * @param genSet TODO Find out what this does...
-     * @return The type for this usage of this expression.
-     * @throws HaskellException The type tree contains an application of an incompatible type.
-     */
-    public abstract Type analyze(final Env env, final GenSet genSet) throws HaskellException;
-
-    /**
      * Analyzes the type tree and resolves the type for this usage of this expression, using an empty GenSet. This
      * method can be used to call when analyzing the root of the expression tree (the first step in the type inference
      * of an expression).
@@ -67,7 +56,7 @@ public abstract class Expr extends HaskellObject {
      * @throws HaskellException The type tree contains an application of an incompatible type.
      */
     public Type analyze(final Env env) throws HaskellException {
-        return this.analyze(env, new GenSet());
+        return this.analyze(env);
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Function.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.haskell.expr;
 
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 
@@ -34,7 +33,7 @@ public class Function extends Expr {
         }
 
         @Override
-        public Type analyze(Env env, GenSet genSet) throws HaskellException {
+        public Type analyze(Env env) throws HaskellException {
             return this.type;
         }
 
@@ -81,7 +80,7 @@ public class Function extends Expr {
     }
 
     @Override
-    public Type analyze(Env env, GenSet genSet) throws HaskellException {
+    public Type analyze(Env env) throws HaskellException {
         Type type = this.expr.analyze(env).prune().getFresh();
 
         for (int i = this.arguments.size(); i > 0; i--) {

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Ident.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Ident.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.haskell.expr;
 
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.Type;
 
 import java.util.Optional;
@@ -26,7 +25,7 @@ public class Ident extends Expr {
     }
 
     @Override
-    public final Type analyze(final Env env, final GenSet genSet) throws HaskellException {
+    public final Type analyze(final Env env) throws HaskellException {
         // Rule [Var]:
         // IFF  we know (from the env) that the type of this expr is x
         // THEN the type of this expr is x.

--- a/Code/src/main/java/nl/utwente/group10/haskell/expr/Value.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/expr/Value.java
@@ -2,7 +2,6 @@ package nl.utwente.group10.haskell.expr;
 
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.Type;
 
 /**
@@ -32,7 +31,7 @@ public class Value extends Expr {
     }
 
     @Override
-    public final Type analyze(final Env env, final GenSet genSet) throws HaskellTypeError {
+    public final Type analyze(final Env env) throws HaskellTypeError {
         return this.type;
     }
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/hindley/GenSet.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/hindley/GenSet.java
@@ -1,8 +1,0 @@
-package nl.utwente.group10.haskell.hindley;
-
-import java.util.HashSet;
-
-import nl.utwente.group10.haskell.type.VarT;
-
-public class GenSet extends HashSet<VarT> {
-}

--- a/Code/src/main/java/nl/utwente/group10/haskell/hindley/package-info.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/hindley/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Contains an implementation of the Hindley-Milner type inference algorithm.
- */
-package nl.utwente.group10.haskell.hindley;

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/ConstT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/ConstT.java
@@ -63,8 +63,9 @@ public class ConstT extends Type {
             out.append(arg.toHaskellType(10));
         }
 
-        if (fixity > 9 && this.args.length > 0)
+        if (fixity > 9 && this.args.length > 0) {
         	return "(" + out.toString() + ")";
+        }
         			
         return out.toString();
     }

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/ConstT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/ConstT.java
@@ -54,15 +54,18 @@ public class ConstT extends Type {
     }
 
     @Override
-    public String toHaskellType() {
+    public String toHaskellType(final int fixity) {
         StringBuilder out = new StringBuilder();
         out.append(this.constructor);
 
         for (Type arg : this.args) {
             out.append(" ");
-            out.append(arg.toHaskellType());
+            out.append(arg.toHaskellType(10));
         }
 
+        if (fixity > 9 && this.args.length > 0)
+        	return "(" + out.toString() + ")";
+        			
         return out.toString();
     }
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/FuncT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/FuncT.java
@@ -13,21 +13,21 @@ public class FuncT extends ConstT {
     }
 
     @Override
-    public final String toHaskellType() {
+    public final String toHaskellType(final int fixity) {
         final StringBuilder out = new StringBuilder();
         final Type[] args = this.getArgs();
 
-        out.append("(");
+        out.append(args[0].toHaskellType(1));
 
-        for (int i = 0; i < args.length; i++) {
-            out.append(args[i].toHaskellType());
-
-            if (i + 1 < args.length) {
-                out.append(" -> ");
-            }
+        for (int i = 1; i < args.length; i++) {
+        	out.append(" -> ");
+        	final int fix = i == args.length-1 ? 0 : 1;
+            out.append(args[i].toHaskellType(fix));
         }
 
-        out.append(")");
+        if (fixity > 0)
+        	return "(" + out.toString() + ")";
+        	
         return out.toString();
     }
 

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/ListT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/ListT.java
@@ -13,8 +13,8 @@ public class ListT extends ConstT {
     }
 
     @Override
-    public final String toHaskellType() {
-        return "[" + this.getArgs()[0].toHaskellType() + "]";
+    public final String toHaskellType(final int fixity) {
+        return "[" + this.getArgs()[0].toHaskellType(0) + "]";
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TupleT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TupleT.java
@@ -12,14 +12,14 @@ public class TupleT extends ConstT {
     }
 
     @Override
-    public final String toHaskellType() {
+    public final String toHaskellType(final int fixity) {
         StringBuilder out = new StringBuilder();
         Type[] args = this.getArgs();
 
         out.append("(");
 
         for (int i = 0; i < args.length; i++) {
-            out.append(args[i].toHaskellType());
+            out.append(args[i].toHaskellType(0));
 
             if (i + 1 < args.length) {
                 out.append(", ");

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/Type.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/Type.java
@@ -30,7 +30,15 @@ public abstract class Type extends HaskellObject implements Comparable<Type> {
     /**
      * @return The Haskell (type) representation of this type.
      */
-    public abstract String toHaskellType();
+    public String toHaskellType() {
+    	return this.toHaskellType(0);
+    }
+
+    /**
+     * @param The fixity of the context the type is shown in.
+     * @return The Haskell (type) representation of this type.
+     */
+    public abstract String toHaskellType(final int fixity);
 
     /**
      * @return An exactly alike deep copy of this type.

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/Type.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/Type.java
@@ -36,6 +36,7 @@ public abstract class Type extends HaskellObject implements Comparable<Type> {
 
     /**
      * @param The fixity of the context the type is shown in.
+     * The fixity is small positive number derived from operator precedence (see also Section 4.4.2 of the Haskell language report)
      * @return The Haskell (type) representation of this type.
      */
     public abstract String toHaskellType(final int fixity);

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
@@ -20,7 +20,7 @@ public final class TypeChecker {
     /**
      * Offset for the creation of variable types.
      */
-    static int tvOffset = -1;
+    static int tvOffset = 0;
 
     static {
         TypeChecker.logger.setLevel(Level.WARNING);
@@ -147,8 +147,7 @@ public final class TypeChecker {
      * @return A new variable type.
      */
     public static VarT makeVariable(final String prefix, final Set<TypeClass> constraints) {
-        TypeChecker.tvOffset += 1;
-        return new VarT(prefix, TypeChecker.tvOffset, constraints, null);
+        return new VarT(prefix, TypeChecker.tvOffset++, constraints, null);
     }
 
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
@@ -20,7 +20,7 @@ public final class TypeChecker {
     /**
      * Offset for the creation of variable types.
      */
-    static int tvOffset = 0;
+    static int tvOffset = -1;
 
     static {
         TypeChecker.logger.setLevel(Level.WARNING);
@@ -61,7 +61,7 @@ public final class TypeChecker {
                     // therefore lie inside the union of those type classes: if a must be in Num and Show, and b must be
                     // in Num and Read, then whatever the resulting type will be must be in Num, Show and Read.
 
-                    VarT t = TypeChecker.makeVariable(VarT.union(va, vb));
+                    VarT t = TypeChecker.makeVariable(va.getPrefix(), VarT.union(va, vb));
 
                     va.setInstance(t);
                     vb.setInstance(t);
@@ -142,26 +142,20 @@ public final class TypeChecker {
 
     /**
      * Creates and returns a new {@code VarT} instance with a unique identifier.
+     * @param prefix The base name of the type variable.
      * @param constraints Constraints for the new VarT.
      * @return A new variable type.
      */
-    public static VarT makeVariable(final Set<TypeClass> constraints) {
-        final String name;
-
-        name = TypeChecker.tvOffset <= 25
-                ? String.valueOf((char) ('α' + TypeChecker.tvOffset))
-                : Integer.toString(TypeChecker.tvOffset);
-
+    public static VarT makeVariable(final String prefix, final Set<TypeClass> constraints) {
         TypeChecker.tvOffset += 1;
-
-        return new VarT(name, constraints, null);
+        return new VarT(prefix, TypeChecker.tvOffset, constraints, null);
     }
 
     /**
      * Creates and returns a new {@code VarT} instance with a unique identifier.
      * @return A new variable type.
      */
-    public static VarT makeVariable() {
-        return makeVariable(new HashSet<TypeClass>());
+    public static VarT makeVariable(final String prefix) {
+        return makeVariable(prefix, new HashSet<TypeClass>());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
@@ -9,7 +9,7 @@ import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
 import nl.utwente.group10.haskell.expr.Expr;
 
 /**
- * Implementation of the Hindley-Milner type system for Haskell types and expressions.
+ * Implementation of a typechecker for a simplified variant of Haskell.
  */
 public final class TypeChecker {
     /**

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/TypeChecker.java
@@ -1,4 +1,4 @@
-package nl.utwente.group10.haskell.hindley;
+package nl.utwente.group10.haskell.type;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -7,19 +7,15 @@ import java.util.logging.Logger;
 
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
 import nl.utwente.group10.haskell.expr.Expr;
-import nl.utwente.group10.haskell.type.ConstT;
-import nl.utwente.group10.haskell.type.Type;
-import nl.utwente.group10.haskell.type.TypeClass;
-import nl.utwente.group10.haskell.type.VarT;
 
 /**
  * Implementation of the Hindley-Milner type system for Haskell types and expressions.
  */
-public final class HindleyMilner {
+public final class TypeChecker {
     /**
      * Logger for this class.
      */
-    private static final Logger logger = Logger.getLogger(HindleyMilner.class.getName());
+    private static final Logger logger = Logger.getLogger(TypeChecker.class.getName());
 
     /**
      * Offset for the creation of variable types.
@@ -27,14 +23,14 @@ public final class HindleyMilner {
     static int tvOffset = 0;
 
     static {
-        HindleyMilner.logger.setLevel(Level.WARNING);
+        TypeChecker.logger.setLevel(Level.WARNING);
         // Changing this to Level.INFO will show debug messages.
     }
     
     /**
      * Private constructor - methods in this class are static.
      */
-    private HindleyMilner() {
+    private TypeChecker() {
     }
 
     public static void unify(final Type t1, final Type t2) throws HaskellTypeError {
@@ -45,12 +41,12 @@ public final class HindleyMilner {
         final Type a = t1.prune();
         final Type b = t2.prune();
         
-        HindleyMilner.logger.info(String.format("Unifying types %s and %s for context %s", t1, t2, context));
+        TypeChecker.logger.info(String.format("Unifying types %s and %s for context %s", t1, t2, context));
 
         if (a instanceof VarT && !a.equals(b)) {
             // First, prevent ourselves from going into an infinite loop
-            if (HindleyMilner.occursInType(a, b)) {
-                HindleyMilner.logger.info(String.format("Recursion in types %s and %s for context %s", a, b, context));
+            if (TypeChecker.occursInType(a, b)) {
+                TypeChecker.logger.info(String.format("Recursion in types %s and %s for context %s", a, b, context));
                 throw new HaskellTypeError(String.format("%s ∈ %s", a, b), context, a, b);
             }
 
@@ -65,7 +61,7 @@ public final class HindleyMilner {
                     // therefore lie inside the union of those type classes: if a must be in Num and Show, and b must be
                     // in Num and Read, then whatever the resulting type will be must be in Num, Show and Read.
 
-                    VarT t = HindleyMilner.makeVariable(VarT.union(va, vb));
+                    VarT t = TypeChecker.makeVariable(VarT.union(va, vb));
 
                     va.setInstance(t);
                     vb.setInstance(t);
@@ -85,14 +81,14 @@ public final class HindleyMilner {
                 if (((VarT) a).hasConstraint(b)) {
                     ((VarT) a).setInstance(b);
                 } else {
-                    HindleyMilner.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
+                    TypeChecker.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
                     throw new HaskellTypeError(String.format("%s ∉ constraints of %s", b, a), context, a, b);
                 }
             }
         } else if (a instanceof ConstT && b instanceof VarT) {
             // Example: we have to unify Int and α.
             // Same as above, but mirrored.
-            HindleyMilner.unify(context, b, a);
+            TypeChecker.unify(context, b, a);
         } else if (a instanceof ConstT && b instanceof ConstT) {
             // Example: we have to unify Int and Int.
 
@@ -102,20 +98,20 @@ public final class HindleyMilner {
             // If the constructor doesn't match, give up right away.
             // Example: trying to unify String and Int.
             if (!ao.getConstructor().equals(bo.getConstructor())) {
-                HindleyMilner.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
+                TypeChecker.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
                 throw new HaskellTypeError(String.format("%s ⊥ %s", a, b), context, a, b);
             }
 
             // If the two types have different amounts of arguments, bail.
             // Example: trying to unify (,) Int Int and (,) Int Int Int
             if (ao.getArgs().length != bo.getArgs().length) {
-                HindleyMilner.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
+                TypeChecker.logger.info(String.format("Unable to unify types %s and %s for context %s", a, b, context));
                 throw new HaskellTypeError(String.format("%s ⊥ %s", a, b), context, a, b);
             }
 
             // Other than that, types can be unified if each of the arguments can be.
             for (int i = 0; i < ao.getArgs().length; i++) {
-                HindleyMilner.unify(context, ao.getArgs()[i], bo.getArgs()[i]);
+                TypeChecker.unify(context, ao.getArgs()[i], bo.getArgs()[i]);
             }
         }
     }
@@ -152,11 +148,11 @@ public final class HindleyMilner {
     public static VarT makeVariable(final Set<TypeClass> constraints) {
         final String name;
 
-        name = HindleyMilner.tvOffset <= 25
-                ? String.valueOf((char) ('α' + HindleyMilner.tvOffset))
-                : Integer.toString(HindleyMilner.tvOffset);
+        name = TypeChecker.tvOffset <= 25
+                ? String.valueOf((char) ('α' + TypeChecker.tvOffset))
+                : Integer.toString(TypeChecker.tvOffset);
 
-        HindleyMilner.tvOffset += 1;
+        TypeChecker.tvOffset += 1;
 
         return new VarT(name, constraints, null);
     }

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -12,9 +12,14 @@ import java.util.Set;
  */
 public class VarT extends Type {
     /**
-     * Identifier for type checking within {@code FuncT} and {@code TupleT} types.
+     * Base name of the type variable.
      */
-    private final String name;
+    private final String prefix;
+
+    /**
+     * Number to make a name of the type variable unique.
+     */
+    private final int uid;
 
     /**
      * The instance for this type.
@@ -32,8 +37,9 @@ public class VarT extends Type {
      * @param constraints The set of constraints for this type.
      * @param instance The instance of this type.
      */
-    public VarT(final String name, final Set<TypeClass> constraints, final Type instance) {
-        this.name = name.toLowerCase();
+    public VarT(final String prefix, final int uid, final Set<TypeClass> constraints, final Type instance) {
+        this.prefix = prefix.toLowerCase();
+        this.uid = uid;
         this.instance = Optional.ofNullable(instance);
         this.constraints = constraints;
     }
@@ -44,14 +50,24 @@ public class VarT extends Type {
      * @param typeclasses The type classes that are accepted by this type.
      */
     public VarT(final String name, final TypeClass ... typeclasses) {
-        this(name, new HashSet<TypeClass>(Arrays.asList(typeclasses)), null);
+        this(name, 0, new HashSet<TypeClass>(Arrays.asList(typeclasses)), null);
+    }
+
+    /**
+     * @return The name of this variable type.
+     */
+    public final String getPrefix() {
+        return this.prefix;
     }
 
     /**
      * @return The name of this variable type.
      */
     public final String getName() {
-        return this.name;
+    	if (this.uid == 0)
+    		return this.prefix;
+    	
+        return this.prefix + Integer.toString(this.uid);
     }
 
     /**
@@ -104,14 +120,14 @@ public class VarT extends Type {
         final StringBuilder out = new StringBuilder();
 
         if (this.constraints.isEmpty()) {
-            out.append(this.name);
+            out.append(this.getName());
         } else {
             out.append("(");
 
             int i = 0;
 
             for (TypeClass tc : this.constraints) {
-                out.append(String.format("%s %s", tc.getName(), this.name));
+                out.append(String.format("%s %s", tc.getName(), this.getName()));
                 if (i + 1 < this.constraints.size()) {
                     out.append(", ");
                 }
@@ -132,12 +148,12 @@ public class VarT extends Type {
             instance = this.instance.get().getFresh();
         }
 
-        return new VarT(this.name, this.constraints, instance);
+        return new VarT(this.prefix, this.uid, this.constraints, instance);
     }
 
     @Override
     public final String toString() {
-        return this.instance.isPresent() ? String.format("%s:%s", this.name, this.instance.get()) : this.name;
+        return this.instance.isPresent() ? String.format("%s:%s", this.getName(), this.instance.get()) : this.getName();
     }
 
     /** Return the set of typeclasses that is the union of both arguments' constraints. */

--- a/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/type/VarT.java
@@ -100,7 +100,7 @@ public class VarT extends Type {
     }
 
     @Override
-    public final String toHaskellType() {
+    public final String toHaskellType(final int fixity) {
         final StringBuilder out = new StringBuilder();
 
         if (this.constraints.isEmpty()) {

--- a/Code/src/main/java/nl/utwente/group10/haskell/typeparser/TypeBuilderListener.java
+++ b/Code/src/main/java/nl/utwente/group10/haskell/typeparser/TypeBuilderListener.java
@@ -42,7 +42,7 @@ class TypeBuilderListener extends TypeBaseListener {
     @Override
     public void exitTypeClasses(TypeParser.TypeClassesContext ctx) {
         for (String varName : this.constraints.keySet()) {
-            vars.put(varName, new VarT(varName, (Set<TypeClass>) this.constraints.get(varName), null));
+            vars.put(varName, new VarT(varName, 0, (Set<TypeClass>) this.constraints.get(varName), null));
         }
     }
 

--- a/Code/src/main/java/nl/utwente/group10/tcc/TypeCheckerChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/tcc/TypeCheckerChecker.java
@@ -13,8 +13,8 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 import nl.utwente.group10.haskell.type.FuncT;
+import nl.utwente.group10.haskell.type.TypeChecker;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.haskell.type.VarT;
 import nl.utwente.group10.haskell.typeparser.TypeBuilder;
@@ -56,11 +56,11 @@ public class TypeCheckerChecker extends Application implements Initializable {
     public final void recalculate() {
         Type funT = tb.build(fun.getText());
         Type argT = tb.build(arg.getText());
-        Type resT = HindleyMilner.makeVariable();
+        Type resT = TypeChecker.makeVariable();
 
         // First, check if funT is a function
         try {
-            HindleyMilner.unify(funT, new FuncT(new VarT(""), new VarT("")));
+            TypeChecker.unify(funT, new FuncT(new VarT(""), new VarT("")));
         } catch (HaskellTypeError haskellTypeError) {
             res.setText("⊥ (Invalid function type.)");
             return;
@@ -68,7 +68,7 @@ public class TypeCheckerChecker extends Application implements Initializable {
 
         // Then check if the argument is reasonable
         try {
-            HindleyMilner.unify(funT, new FuncT(argT, resT));
+            TypeChecker.unify(funT, new FuncT(argT, resT));
             res.setText(resT.prune().toHaskellType());
         } catch (HaskellTypeError haskellTypeError) {
             res.setText("⊥ (Types do not unify.)");

--- a/Code/src/main/java/nl/utwente/group10/tcc/TypeCheckerChecker.java
+++ b/Code/src/main/java/nl/utwente/group10/tcc/TypeCheckerChecker.java
@@ -56,11 +56,11 @@ public class TypeCheckerChecker extends Application implements Initializable {
     public final void recalculate() {
         Type funT = tb.build(fun.getText());
         Type argT = tb.build(arg.getText());
-        Type resT = TypeChecker.makeVariable();
+        Type resT = TypeChecker.makeVariable("x");
 
         // First, check if funT is a function
         try {
-            TypeChecker.unify(funT, new FuncT(new VarT(""), new VarT("")));
+            TypeChecker.unify(funT, new FuncT(new VarT("a"), new VarT("b")));
         } catch (HaskellTypeError haskellTypeError) {
             res.setText("⊥ (Invalid function type.)");
             return;

--- a/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/group10/ghcj/GhciSessionTest.java
@@ -4,7 +4,6 @@ import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.expr.Value;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.ConstT;
 
 import org.junit.Assert;
@@ -15,14 +14,12 @@ public class GhciSessionTest {
     /** Our session with Ghci. */
     private GhciSession ghci = null;
     private Env env;
-    private GenSet genSet;
 
     private Expr pi;
 
     @Before
     public void setUp() throws GhciException {
         this.env = new Env();
-        this.genSet = new GenSet();
         this.ghci = new GhciSession();
 
         this.env.getExprTypes().put("my_pi", new ConstT("Float"));

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ApplyTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.ConstT;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.ListT;
@@ -16,10 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class ApplyTest {
-    private final Type alpha = new VarT("a");
     private final Type beta = new VarT("b");
-    private final Type gamma = new VarT("c");
-    private final Type alphaList = new ListT(this.alpha);
     private final Type betaList = new ListT(this.beta);
     private final Type integer = new ConstT("Int");
     private final Type integerList = new ListT(this.integer);
@@ -27,12 +23,10 @@ public class ApplyTest {
     private final Type stringList = new ListT(this.string);
 
     private Env env;
-    private GenSet genSet;
 
     @Before
     public final void setUp() {
         this.env = new Env();
-        this.genSet = new GenSet();
 
         this.env.addExpr("id", "a -> a");
         this.env.addExpr("(+)", "Int -> Int -> Int");
@@ -46,7 +40,7 @@ public class ApplyTest {
         final Apply apply = new Apply(new Ident("id"), new Value(this.integer, "42"));
 
         assertEquals("(id 42)", apply.toHaskell());
-        assertEquals(this.integer.toHaskellType(), apply.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals(this.integer.toHaskellType(), apply.analyze(this.env).prune().toHaskellType());
     }
 
     @Test
@@ -57,8 +51,8 @@ public class ApplyTest {
         assertEquals("((+) 42)", apply1.toHaskell());
         assertEquals("(((+) 42) 42)", apply2.toHaskell());
 
-        assertEquals(new FuncT(this.integer, this.integer).toHaskellType(), apply1.analyze(this.env, this.genSet).prune().toHaskellType());
-        assertEquals(this.integer.toHaskellType(), apply2.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals(new FuncT(this.integer, this.integer).toHaskellType(), apply1.analyze(this.env).prune().toHaskellType());
+        assertEquals(this.integer.toHaskellType(), apply2.analyze(this.env).prune().toHaskellType());
     }
 
     @Test
@@ -70,8 +64,8 @@ public class ApplyTest {
         assertEquals("(map ((+) 42))", apply1.toHaskell());
         assertEquals("((map ((+) 42)) [1, 2, 3, 5, 7])", apply2.toHaskell());
 
-        assertEquals(new FuncT(this.integerList, this.integerList).toHaskellType(), apply1.analyze(this.env, this.genSet).prune().toHaskellType());
-        assertEquals(this.integerList.toHaskellType(), apply2.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals(new FuncT(this.integerList, this.integerList).toHaskellType(), apply1.analyze(this.env).prune().toHaskellType());
+        assertEquals(this.integerList.toHaskellType(), apply2.analyze(this.env).prune().toHaskellType());
     }
 
     @Test
@@ -82,8 +76,8 @@ public class ApplyTest {
         assertEquals("(zip [1, 2, 3, 5, 7])", apply1.toHaskell());
         assertEquals("((zip [1, 2, 3, 5, 7]) [\"a\", \"b\", \"c\"])", apply2.toHaskell());
 
-        assertEquals(new FuncT(this.betaList, new ListT(new TupleT(this.integer, this.beta))).toHaskellType(), apply1.analyze(this.env, this.genSet).prune().toHaskellType());
-        assertEquals(new ListT(new TupleT(this.integer, this.string)).toHaskellType(), apply2.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals(new FuncT(this.betaList, new ListT(new TupleT(this.integer, this.beta))).toHaskellType(), apply1.analyze(this.env).prune().toHaskellType());
+        assertEquals(new ListT(new TupleT(this.integer, this.string)).toHaskellType(), apply2.analyze(this.env).prune().toHaskellType());
     }
 
     @Test(expected=HaskellException.class)
@@ -94,8 +88,8 @@ public class ApplyTest {
         assertEquals("(lcm 42)", apply1.toHaskell());
         assertEquals("((lcm 42) \"haskell\")", apply2.toHaskell());
 
-        assertEquals(new FuncT(this.integer, this.integer).toHaskellType(), apply1.analyze(this.env, this.genSet).prune().toHaskellType());
-        assertNotEquals(this.string, apply2.analyze(this.env, this.genSet).prune().toHaskellType());
-        assertNotEquals(this.integer, apply2.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals(new FuncT(this.integer, this.integer).toHaskellType(), apply1.analyze(this.env).prune().toHaskellType());
+        assertNotEquals(this.string, apply2.analyze(this.env).prune().toHaskellType());
+        assertNotEquals(this.integer, apply2.analyze(this.env).prune().toHaskellType());
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.haskell.expr;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
 import nl.utwente.group10.haskell.exceptions.HaskellTypeError;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.*;
 
 import org.junit.Before;
@@ -14,19 +13,15 @@ import static org.junit.Assert.*;
 public class ExprTest {
     private final Type alpha = new VarT("a");
     private final Type beta = new VarT("b");
-    private final Type alphaList = new ListT(this.alpha);
-    private final Type betaList = new ListT(this.beta);
     private final ConstT integer = new ConstT("Int");
     private final ConstT floating = new ConstT("Float");
     private final ConstT doubl = new ConstT("Double");
     private final ConstT string = new ConstT("String");
 
     private final TypeClass num = new TypeClass("Num", integer, floating, doubl);
-    private final Type numT = new VarT("n", num);
 
     private Expr expr;
     private Env env;
-    private GenSet genSet;
 
     @Before
     public final void setUp() {
@@ -42,7 +37,6 @@ public class ExprTest {
         );
 
         this.env = new Env();
-        this.genSet = new GenSet();
 
         this.env.addTypeClass(this.num);
         this.env.addExpr("(*)", "Num a => a -> a -> a");
@@ -51,7 +45,7 @@ public class ExprTest {
 
     @Test
     public final void testAnalyze() throws HaskellException {
-        assertEquals("[(Int -> Int)]", this.expr.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertEquals("[(Int -> Int)]", this.expr.analyze(this.env).prune().toHaskellType());
     }
 
     @Test
@@ -75,7 +69,7 @@ public class ExprTest {
                         "[\"a\", \"b\", \"c\"]"
                 )
         );
-        assertNotEquals("[(String -> String)]", expr.analyze(this.env, this.genSet).prune().toHaskellType());
+        assertNotEquals("[(String -> String)]", expr.analyze(this.env).prune().toHaskellType());
     }
 
     @Test

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ExprTest.java
@@ -45,7 +45,7 @@ public class ExprTest {
 
     @Test
     public final void testAnalyze() throws HaskellException {
-        assertEquals("[(Int -> Int)]", this.expr.analyze(this.env).prune().toHaskellType());
+        assertEquals("[Int -> Int]", this.expr.analyze(this.env).prune().toHaskellType());
     }
 
     @Test

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/FunctionTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/FunctionTest.java
@@ -46,11 +46,11 @@ public class FunctionTest {
         Expr applies = new Apply(new Ident("(+)"), arg);
         Function f = new Function(applies, arg);
 
-        assertEquals("(Int -> (Int -> Int))", f.analyze(this.env).prune().toHaskellType());
+        assertEquals("Int -> Int -> Int", f.analyze(this.env).prune().toHaskellType());
 
         Function.FunctionArgument arg1 = new Function.FunctionArgument(new ConstT("Int"));
         Function add5 = new Function(new Apply(new Apply(f, new Value(new ConstT("Int"), "5")), arg1), arg1);
 
-        assertEquals("(Int -> Int)", add5.analyze(this.env).prune().toHaskellType());
+        assertEquals("Int -> Int", add5.analyze(this.env).prune().toHaskellType());
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/IdentTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/IdentTest.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.haskell.expr;
 import static org.junit.Assert.assertEquals;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.FuncT;
 import nl.utwente.group10.haskell.type.Type;
 import nl.utwente.group10.haskell.type.VarT;
@@ -15,19 +14,17 @@ public class IdentTest {
     private final Type alpha = new VarT("a");
 
     private Env env;
-    private GenSet genSet;
 
     @Before
     public final void setUp() {
         this.env = new Env();
-        this.genSet = new GenSet();
 
         this.env.addExpr("id", "a -> a");
     }
 
     @Test
     public final void testAnalyze() throws HaskellException {
-        assertEquals(new FuncT(this.alpha, this.alpha).toHaskellType(), new Ident("id").analyze(this.env, this.genSet).toHaskellType());
+        assertEquals(new FuncT(this.alpha, this.alpha).toHaskellType(), new Ident("id").analyze(this.env).toHaskellType());
     }
 
     @Test
@@ -37,6 +34,6 @@ public class IdentTest {
 
     @Test(expected=HaskellException.class)
     public final void testIncorrectName() throws HaskellException {
-        new Ident("id").analyze(new Env(), new GenSet());
+        new Ident("id").analyze(new Env());
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/expr/ValueTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/expr/ValueTest.java
@@ -3,7 +3,6 @@ package nl.utwente.group10.haskell.expr;
 import static org.junit.Assert.assertEquals;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.exceptions.HaskellException;
-import nl.utwente.group10.haskell.hindley.GenSet;
 import nl.utwente.group10.haskell.type.ConstT;
 import nl.utwente.group10.haskell.type.Type;
 
@@ -15,7 +14,7 @@ public class ValueTest {
     @Test
     public final void testToHaskell() throws HaskellException {
         final Expr v = new Value(this.integer, "10");
-        assertEquals(this.integer.toHaskellType(), v.analyze(new Env(), new GenSet()).prune().toHaskellType());
+        assertEquals(this.integer.toHaskellType(), v.analyze(new Env()).prune().toHaskellType());
         assertEquals("10", v.toHaskell());
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -11,7 +11,6 @@ import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.expr.Value;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 
 import org.junit.Test;
 
@@ -51,19 +50,19 @@ public class ApplyTest {
         
         Expr e1 = new Ident("undefined");
         Type t1 = e1.analyze(env).prune();
-        HindleyMilner.unify(t1, new ConstT("Float"));
+        TypeChecker.unify(t1, new ConstT("Float"));
         // t1 Should unfiy with everything (the type of t1 should be 'a').
         // No exception thrown -> Types are the same, as expected. The test will
         // fail if an Exception is thrown.
         
         Expr e2 = new Apply(e0, e1);
         Type t2 = e2.analyze(env).prune();
-        Type num = HindleyMilner.makeVariable(ImmutableSet.of(env.getTypeClasses().get("Num")));
-        HindleyMilner.unify(t2, new FuncT(num, num));
+        Type num = TypeChecker.makeVariable(ImmutableSet.of(env.getTypeClasses().get("Num")));
+        TypeChecker.unify(t2, new FuncT(num, num));
         
         Expr e3 = new Apply(e2, new Ident("undefined"));
         Type t3 = e3.analyze(env).prune();
-        HindleyMilner.unify(t3, new ConstT("Float"));
+        TypeChecker.unify(t3, new ConstT("Float"));
         // t3 Should unfiy with everything (the type of t3 should be 'a').
         // No exception thrown -> Types are the same, as expected. The test will
         // fail if an Exception is thrown.

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -57,7 +57,7 @@ public class ApplyTest {
         
         Expr e2 = new Apply(e0, e1);
         Type t2 = e2.analyze(env).prune();
-        Type num = TypeChecker.makeVariable(ImmutableSet.of(env.getTypeClasses().get("Num")));
+        Type num = TypeChecker.makeVariable("n", ImmutableSet.of(env.getTypeClasses().get("Num")));
         TypeChecker.unify(t2, new FuncT(num, num));
         
         Expr e3 = new Apply(e2, new Ident("undefined"));

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ApplyTest.java
@@ -21,7 +21,7 @@ public class ApplyTest {
         
         Expr e0 = new Ident("(+)");
         Type t0 = e0.analyze(env).prune();
-        assertEquals("((Num a) -> ((Num a) -> (Num a)))", t0.toHaskellType());
+        assertEquals("(Num a) -> (Num a) -> (Num a)", t0.toHaskellType());
         
         Expr e1 = new Value(new ConstT("Float"), "5.0");
         Type t1 = e1.analyze(env).prune();
@@ -29,7 +29,7 @@ public class ApplyTest {
         
         Expr e2 = new Apply(e0, e1);
         Type t2 = e2.analyze(env).prune();
-        assertEquals("(Float -> Float)", t2.toHaskellType());
+        assertEquals("Float -> Float", t2.toHaskellType());
         
         Expr e3 = new Value(new ConstT("Float"), "5.0");
         Type t3 = e3.analyze(env).prune();
@@ -46,7 +46,7 @@ public class ApplyTest {
         
         Expr e0 = new Ident("(+)");
         Type t0 = e0.analyze(env).prune();
-        assertEquals("((Num a) -> ((Num a) -> (Num a)))", t0.toHaskellType());
+        assertEquals("(Num a) -> (Num a) -> (Num a)", t0.toHaskellType());
         
         Expr e1 = new Ident("undefined");
         Type t1 = e1.analyze(env).prune();

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/BubbleTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/BubbleTest.java
@@ -39,9 +39,9 @@ public class BubbleTest {
 
     @Test
     public void testBubbleAddition() throws Exception {
-        VarT a = TypeChecker.makeVariable();
-        VarT b = TypeChecker.makeVariable();
-        VarT c = TypeChecker.makeVariable();
+        VarT a = TypeChecker.makeVariable("a");
+        VarT b = TypeChecker.makeVariable("b");
+        VarT c = TypeChecker.makeVariable("c");
         ConstT floatT = new ConstT("Float");
 
         Apply apply = new Apply(
@@ -70,7 +70,7 @@ public class BubbleTest {
         ConstT Float = new ConstT("Float");
         TypeClass Num = new TypeClass("Num", Float);
         VarT a = new VarT("a", Num);
-        VarT b = TypeChecker.makeVariable();
+        VarT b = new VarT("b");
 
         Apply apply = new Apply(
                 new Apply(

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/BubbleTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/BubbleTest.java
@@ -3,7 +3,7 @@ package nl.utwente.group10.haskell.type;
 import nl.utwente.group10.haskell.env.Env;
 import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Value;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -39,9 +39,9 @@ public class BubbleTest {
 
     @Test
     public void testBubbleAddition() throws Exception {
-        VarT a = HindleyMilner.makeVariable();
-        VarT b = HindleyMilner.makeVariable();
-        VarT c = HindleyMilner.makeVariable();
+        VarT a = TypeChecker.makeVariable();
+        VarT b = TypeChecker.makeVariable();
+        VarT c = TypeChecker.makeVariable();
         ConstT floatT = new ConstT("Float");
 
         Apply apply = new Apply(
@@ -70,7 +70,7 @@ public class BubbleTest {
         ConstT Float = new ConstT("Float");
         TypeClass Num = new TypeClass("Num", Float);
         VarT a = new VarT("a", Num);
-        VarT b = HindleyMilner.makeVariable();
+        VarT b = TypeChecker.makeVariable();
 
         Apply apply = new Apply(
                 new Apply(

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/ConstTTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/ConstTTest.java
@@ -20,7 +20,7 @@ public class ConstTTest {
     @Test
     public final void testPrune() {
         final ConstT integer = new ConstT("Integer");
-        final VarT a = new VarT("a", new HashSet<>(), integer);
+        final VarT a = new VarT("a", 0, new HashSet<>(), integer);
 
         assertNotEquals(integer, a);
         assertEquals(integer, a.prune());

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/FuncTTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/FuncTTest.java
@@ -9,6 +9,6 @@ public class FuncTTest {
     public final void toHaskellTypeTest() {
         final ConstT integer = new ConstT("Integer");
         final FuncT function = new FuncT(integer, integer);
-        assertEquals("(Integer -> Integer)", function.toHaskellType());
+        assertEquals("Integer -> Integer", function.toHaskellType());
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/SharingTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/SharingTest.java
@@ -1,6 +1,5 @@
 package nl.utwente.group10.haskell.type;
 
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -18,13 +17,13 @@ public class SharingTest {
         assertEquals("Unit", u.toString());
         assertEquals("([] x)", l.toString());
 
-        HindleyMilner.unify(x, y);
+        TypeChecker.unify(x, y);
 
         assertEquals("x:y", x.toString());
         assertEquals("y", y.toString());
         assertEquals("([] x:y)", l.toString());
 
-        HindleyMilner.unify(x, u);
+        TypeChecker.unify(x, u);
 
         assertEquals("Unit", x.prune().toHaskellType());
         assertEquals("Unit", y.prune().toHaskellType());

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/TypeTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/TypeTest.java
@@ -18,7 +18,7 @@ public class TypeTest {
                 )
         );
 
-        assertEquals("([a], (b -> String))", t.toHaskellType());
+        assertEquals("([a], b -> String)", t.toHaskellType());
     }
 
     @Test

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
@@ -20,11 +20,11 @@ public class UnificationTest {
 
         Expr e0 = new Ident("const");
         Type t0 = e0.analyze(env).prune();
-        assertEquals("(a -> (b -> a))", t0.toHaskellType());
+        assertEquals("a -> b -> a", t0.toHaskellType());
 
         Expr e1 = new Apply(e0, new Ident("undefined"));
         Type t1 = e1.analyze(env).prune();
-        assertEquals("(b -> a)", t1.toHaskellType());
+        assertEquals("b -> a", t1.toHaskellType());
 
         Expr e2 = new Apply(e1, new Ident("undefined"));
         Type t2 = e2.analyze(env).prune();
@@ -39,11 +39,11 @@ public class UnificationTest {
         
         Expr e0 = new Ident("const");
         Type t0 = e0.analyze(env).prune();
-        assertEquals("(a -> (b -> a))", t0.toHaskellType());
+        assertEquals("a -> b -> a", t0.toHaskellType());
 
         Expr e1 = new Apply(e0, new Value(new ConstT("Float"), "5.0"));
         Type t1 = e1.analyze(env).prune();
-        assertEquals("(b -> Float)", t1.toHaskellType());
+        assertEquals("b -> Float", t1.toHaskellType());
 
         Expr e2 = new Apply(e1, new Value(new ConstT("Float"), "5.0"));
         Type t2 = e2.analyze(env).prune();

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
@@ -63,7 +63,7 @@ public class UnificationTest {
         Expr e2 = new Apply(e1, new Ident("undefined"));
         Type t2 = e2.analyze(env).prune();
         
-        Type t3 = TypeChecker.makeVariable();
+        Type t3 = TypeChecker.makeVariable("t");
         Type t4 = new ConstT("Bool");
         
         TypeChecker.unify(t3, t4);

--- a/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/type/UnificationTest.java
@@ -9,7 +9,6 @@ import nl.utwente.group10.haskell.expr.Apply;
 import nl.utwente.group10.haskell.expr.Expr;
 import nl.utwente.group10.haskell.expr.Ident;
 import nl.utwente.group10.haskell.expr.Value;
-import nl.utwente.group10.haskell.hindley.HindleyMilner;
 
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ public class UnificationTest {
         Expr e2 = new Apply(e1, new Ident("undefined"));
         Type t2 = e2.analyze(env).prune();
 
-        HindleyMilner.unify(t2, new Ident("undefined").analyze(env));
+        TypeChecker.unify(t2, new Ident("undefined").analyze(env));
         //No exception thrown -> Types are the same, as expected. The test will fail if an Exception is thrown.
     }
 
@@ -64,12 +63,12 @@ public class UnificationTest {
         Expr e2 = new Apply(e1, new Ident("undefined"));
         Type t2 = e2.analyze(env).prune();
         
-        Type t3 = HindleyMilner.makeVariable();
+        Type t3 = TypeChecker.makeVariable();
         Type t4 = new ConstT("Bool");
         
-        HindleyMilner.unify(t3, t4);
+        TypeChecker.unify(t3, t4);
         
-        HindleyMilner.unify(t2, t4);
+        TypeChecker.unify(t2, t4);
     }
 
     @Test
@@ -89,7 +88,7 @@ public class UnificationTest {
 
         e2.analyze(env);
 
-        HindleyMilner.unify(t0, ct);
-        HindleyMilner.unify(t1, ct);
+        TypeChecker.unify(t0, ct);
+        TypeChecker.unify(t1, ct);
     }
 }

--- a/Code/src/test/java/nl/utwente/group10/haskell/typeparser/TypeBuilderTest.java
+++ b/Code/src/test/java/nl/utwente/group10/haskell/typeparser/TypeBuilderTest.java
@@ -20,14 +20,15 @@ public class TypeBuilderTest {
 
     @Test public void testBuildConstT() { this.roundtrip("Int"); }
     @Test public void testBuildVarT()   { this.roundtrip("a"); }
-    @Test public void testBuildFuncT()  { this.roundtrip("(a -> b)"); }
+    @Test public void testBuildFuncT()  { this.roundtrip("a -> b"); }
     @Test public void testBuildListT()  { this.roundtrip("[a]"); }
     @Test public void testBuildTupleT() { this.roundtrip("(String, Int)"); }
     @Test public void testMaybeA()      { this.roundtrip("Maybe a"); }
     @Test public void testMaybeInt()    { this.roundtrip("Maybe Int"); }
     @Test public void testMaybeFunc()   { this.roundtrip("Maybe (Int -> Int)"); }
-    @Test public void testMaybeSink()   { this.roundtrip("(Maybe Int -> Maybe [a])"); }
-    @Test public void testKitchenSink() { this.roundtrip("([a] -> ([b] -> [(a, b)]))"); }
+    @Test public void testMaybeMaybe()  { this.roundtrip("Maybe (Maybe a)"); }
+    @Test public void testMaybeSink()   { this.roundtrip("Maybe Int -> Maybe [a]"); }
+    @Test public void testKitchenSink() { this.roundtrip("[a] -> [b] -> [(a, b)]"); }
 
     @Test public void testTypeClass()   {
         Map<String, TypeClass> typeClasses = new HashMap<>();
@@ -36,8 +37,8 @@ public class TypeBuilderTest {
         TypeBuilder builder = new TypeBuilder(typeClasses);
 
         Assert.assertEquals("(Num a)", builder.build("Num a => a").toHaskellType());
-        Assert.assertEquals("((Num a) -> (Num a))", builder.build("(Num a) => (a -> a)").toHaskellType());
-        Assert.assertEquals("((Num a) -> b)", builder.build("(Num a, Nonexistent b) => a -> b").toHaskellType());
-        Assert.assertEquals("((Num a) -> (Eq b))", builder.build("(Num a, Eq b) => a -> b").toHaskellType());
+        Assert.assertEquals("(Num a) -> (Num a)", builder.build("(Num a) => (a -> a)").toHaskellType());
+        Assert.assertEquals("(Num a) -> b", builder.build("(Num a, Nonexistent b) => a -> b").toHaskellType());
+        Assert.assertEquals("(Num a) -> (Eq b)", builder.build("(Num a, Eq b) => a -> b").toHaskellType());
     }
 }


### PR DESCRIPTION
Fixed the pretty printing of types with repect to parentheses and type variables.
Removed uselss GenSet and moved the typechecker to type package.