### PR TITLE
Add save/save as actions and JSON serializer

### DIFF
--- a/Code/pom.xml
+++ b/Code/pom.xml
@@ -19,6 +19,11 @@
       <version>18.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
       <version>4.5</version>

--- a/Code/src/main/java/nl/utwente/group10/ui/ButtonOverlay.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/ButtonOverlay.java
@@ -23,14 +23,14 @@ public class ButtonOverlay extends StackPane {
     public ButtonOverlay(Node child, CustomUIPane pane) {
         super();
 
-        FlowPane toolBar = makeMenuBar();
+        FlowPane toolBar = makeMenuBar(pane);
         FlowPane buttons = makeZoomBar(pane);
 
         this.getChildren().setAll(child, buttons, toolBar);
     }
 
-    private FlowPane makeMenuBar() {
-        ContextMenu burgerMenu = new GlobalMenu();
+    private FlowPane makeMenuBar(CustomUIPane pane) {
+        ContextMenu burgerMenu = new GlobalMenu(pane);
 
         Button menu = new Button(MENU_LABEL);
         menu.setFocusTraversable(false);

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -1,5 +1,6 @@
 package nl.utwente.group10.ui;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,6 +57,7 @@ public class CustomUIPane extends TactilePane {
 
     private HaskellCatalog catalog;
     private Environment envInstance;
+    private Optional<File> currentFile;
 
     /**
      * Maps expressions to function blocks for looking up the function block responsible for an expression in case of an
@@ -298,5 +300,13 @@ public class CustomUIPane extends TactilePane {
      */
     public FunctionBlock getExprToFunction(Expression expr) {
         return exprToFunction.get(expr);
+    }
+
+    public Optional<File> getCurrentFile() {
+        return currentFile;
+    }
+
+    public void setCurrentFile(File currentFile) {
+        this.currentFile = Optional.of(currentFile);
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/CustomUIPane.java
@@ -57,6 +57,8 @@ public class CustomUIPane extends TactilePane {
 
     private HaskellCatalog catalog;
     private Environment envInstance;
+
+    /** The File we're currently working on, if any. */
     private Optional<File> currentFile;
 
     /**
@@ -302,10 +304,15 @@ public class CustomUIPane extends TactilePane {
         return exprToFunction.get(expr);
     }
 
+    /** Gets the file we're currently working on, if any. */
     public Optional<File> getCurrentFile() {
         return currentFile;
     }
 
+    /**
+     * Sets the file we're currently working on. Probably called from a Save
+     * As/Open operation.
+     */
     public void setCurrentFile(File currentFile) {
         this.currentFile = Optional.of(currentFile);
     }

--- a/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
@@ -64,11 +64,7 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
             Expression expr = block.getExpr();
             String haskell = expr.toHaskell();
 
-            try {
-                json.setText(Exporter.export(pane));
-            } catch (IOException e) {
-                json.setText(e.toString());
-            }
+            json.setText(Exporter.export(pane));
 
             String label = String.format("%s: %s", block.getClass().getSimpleName(), haskell);
             TreeItem<String> root = new TreeItem<>(label);

--- a/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
@@ -13,7 +13,9 @@ import nl.utwente.group10.ghcj.HaskellException;
 import nl.utwente.group10.haskell.expr.Expression;
 import nl.utwente.group10.ui.components.ComponentLoader;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.serialize.Exporter;
 
+import java.io.IOException;
 import java.util.Optional;
 
 /**
@@ -27,6 +29,7 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
 
     @FXML private TreeView<String> tree;
     @FXML private TextArea hs;
+    @FXML private TextArea json;
 
     public InspectorWindow(CustomUIPane parentPane) {
         loadFXML("InspectorWindow");
@@ -60,6 +63,12 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
         this.block.get().ifPresent(block -> {
             Expression expr = block.getExpr();
             String haskell = expr.toHaskell();
+
+            try {
+                json.setText(Exporter.export(pane));
+            } catch (IOException e) {
+                json.setText(e.toString());
+            }
 
             String label = String.format("%s: %s", block.getClass().getSimpleName(), haskell);
             TreeItem<String> root = new TreeItem<>(label);

--- a/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/InspectorWindow.java
@@ -15,7 +15,6 @@ import nl.utwente.group10.ui.components.ComponentLoader;
 import nl.utwente.group10.ui.components.blocks.Block;
 import nl.utwente.group10.ui.serialize.Exporter;
 
-import java.io.IOException;
 import java.util.Optional;
 
 /**

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/Block.java
@@ -1,7 +1,9 @@
 package nl.utwente.group10.ui.components.blocks;
 
+import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.collect.ImmutableMap;
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
@@ -25,6 +27,7 @@ import nl.utwente.group10.ui.components.blocks.input.InputBlock;
 import nl.utwente.group10.ui.components.blocks.output.OutputBlock;
 import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
 import nl.utwente.group10.ui.components.menu.CircleMenu;
+import nl.utwente.group10.ui.serialize.Bundleable;
 
 /**
  * Base block shaped UI Component that other visual elements will extend from.
@@ -42,7 +45,7 @@ import nl.utwente.group10.ui.components.menu.CircleMenu;
  * Each block implementation should also feature it's own FXML implementation.
  * </p>
  */
-public abstract class Block extends StackPane implements ComponentLoader, ConnectionStateDependent, VisualStateDependent {
+public abstract class Block extends StackPane implements Bundleable, ComponentLoader, ConnectionStateDependent, VisualStateDependent {
     /** The pane that is used to hold state and place all components on. */
     private CustomUIPane parentPane;
     
@@ -283,6 +286,23 @@ public abstract class Block extends StackPane implements ComponentLoader, Connec
         CustomAlert alert = new CustomAlert(getPane(), msg);
         getPane().getChildren().add(alert);
         alert.relocate(this.getLayoutX() + 100, this.getLayoutY() + 100);
+    }
 
+    /**
+     * @return class-specific properties of this Block.
+     */
+    protected ImmutableMap<String, Object> toBundleFragment() {
+        return ImmutableMap.of();
+    }
+
+    @Override
+    public Map<String, Object> toBundle() {
+        return ImmutableMap.of(
+            "kind", getClass().getSimpleName(),
+            "id", hashCode(),
+            "x", getLayoutX(),
+            "y", getLayoutY(),
+            "properties", toBundleFragment()
+        );
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/function/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/function/FunctionBlock.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -210,5 +211,10 @@ public class FunctionBlock extends Block implements InputBlock, OutputBlock {
     @Override
     public String toString() {
         return this.getName();
+    }
+
+    @Override
+    protected ImmutableMap<String, Object> toBundleFragment() {
+        return ImmutableMap.of("name", getName(), "knotIndex", getKnotIndex());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/blocks/output/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/blocks/output/ValueBlock.java
@@ -1,5 +1,6 @@
 package nl.utwente.group10.ui.components.blocks.output;
 
+import com.google.common.collect.ImmutableMap;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
@@ -88,5 +89,10 @@ public class ValueBlock extends Block implements OutputBlock {
     @Override
     public String toString() {
         return "ValueBlock[" + getValue() + "]";
+    }
+
+    @Override
+    protected ImmutableMap<String, Object> toBundleFragment() {
+        return ImmutableMap.of("value", value.getValue());
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/lines/Connection.java
@@ -1,12 +1,17 @@
 package nl.utwente.group10.ui.components.lines;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.collect.ImmutableMap;
 import nl.utwente.group10.ui.CustomUIPane;
 import nl.utwente.group10.ui.components.anchors.ConnectionAnchor;
 import nl.utwente.group10.ui.components.anchors.InputAnchor;
 import nl.utwente.group10.ui.components.anchors.OutputAnchor;
 import nl.utwente.group10.ui.components.blocks.Block;
+import nl.utwente.group10.ui.components.blocks.input.InputBlock;
+import nl.utwente.group10.ui.components.blocks.output.OutputBlock;
 import nl.utwente.group10.ui.handlers.ConnectionCreationManager;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
@@ -15,6 +20,7 @@ import javafx.scene.transform.Transform;
 import javafx.beans.value.ObservableValue;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Point2D;
+import nl.utwente.group10.ui.serialize.Bundleable;
 
 
 /**
@@ -32,7 +38,7 @@ import javafx.geometry.Point2D;
  * update the Line's position when the anchor's positions change.
  */
 public class Connection extends ConnectionLine implements
-        ChangeListener<Transform> {
+        ChangeListener<Transform>, Bundleable {
     /** Starting point of this Line that can be Anchored onto other objects. */
     private Optional<OutputAnchor> startAnchor = Optional.empty();
     /** Ending point of this Line that can be Anchored onto other objects. */
@@ -344,5 +350,24 @@ public class Connection extends ConnectionLine implements
     public String toString() {
         return "Connection connecting \n(out) " + startAnchor + "   to\n(in)  "
                 + endAnchor;
+    }
+
+    @Override
+    public Map<String, Object> toBundle() {
+        ImmutableMap.Builder<String, Object> bundle = ImmutableMap.builder();
+
+        startAnchor.ifPresent(start -> {
+            OutputBlock block = (OutputBlock) start.getBlock();
+            bundle.put("startBlock", block.hashCode());
+            bundle.put("startAnchor", 0);
+        });
+
+        endAnchor.ifPresent(end -> {
+            InputBlock block = (InputBlock) end.getBlock();
+            bundle.put("endBlock", block.hashCode());
+            bundle.put("endAnchor", block.getAllInputs().indexOf(end));
+        });
+
+        return bundle.build();
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
@@ -1,19 +1,69 @@
 package nl.utwente.group10.ui.components.menu;
 
 import javafx.application.Platform;
+import javafx.event.ActionEvent;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.stage.FileChooser;
+import javafx.stage.Window;
+import nl.utwente.group10.ui.CustomUIPane;
+
+import java.io.File;
 
 /**
  * A context menu with global actions (i.e. quit).
  */
 public class GlobalMenu extends ContextMenu {
-    public GlobalMenu() {
+    private CustomUIPane pane;
+
+    public GlobalMenu(CustomUIPane pane) {
         super();
+        this.pane = pane;
+
+        MenuItem menuNew = new MenuItem("New");
+        menuNew.setOnAction(this::onNew);
+
+        MenuItem menuOpen = new MenuItem("Open");
+        menuOpen.setOnAction(this::onOpen);
+
+        MenuItem menuSave = new MenuItem("Save");
+        menuSave.setOnAction(this::onSave);
+
+        MenuItem menuSaveAs = new MenuItem("Save as");
+        menuSaveAs.setOnAction(this::onSaveAs);
 
         MenuItem menuQuit = new MenuItem("Quit");
-        menuQuit.setOnAction(e -> Platform.exit());
+        menuQuit.setOnAction(this::onQuit);
 
-        this.getItems().addAll(menuQuit);
+        this.getItems().addAll(menuNew, menuOpen, menuSave, menuSaveAs, menuQuit);
+    }
+
+    private void onNew(ActionEvent actionEvent) {
+        pane.getChildren().clear();
+    }
+
+    private void onOpen(ActionEvent actionEvent) {
+        Window window = pane.getScene().getWindow();
+        File file = new FileChooser().showOpenDialog(window);
+
+        if (file != null) {
+            /* Load file... */
+        }
+    }
+
+    private void onSave(ActionEvent actionEvent) {
+    }
+
+    private void onSaveAs(ActionEvent actionEvent) {
+        Window window = pane.getScene().getWindow();
+        File file = new FileChooser().showSaveDialog(window);
+
+        if (file != null) {
+            /* Save file... */
+        }
+    }
+
+    private void onQuit(ActionEvent actionEvent) {
+        Platform.exit();
     }
 }

--- a/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
@@ -13,6 +13,7 @@ import nl.utwente.group10.ui.serialize.Exporter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A context menu with global actions (i.e. quit).
@@ -56,6 +57,13 @@ public class GlobalMenu extends ContextMenu {
     }
 
     private void onSave(ActionEvent actionEvent) {
+        Optional<File> file = pane.getCurrentFile();
+
+        if (file.isPresent()) {
+            saveTo(file.get());
+        } else {
+            onSaveAs(actionEvent);
+        }
     }
 
     private void onSaveAs(ActionEvent actionEvent) {
@@ -63,15 +71,18 @@ public class GlobalMenu extends ContextMenu {
         File file = new FileChooser().showSaveDialog(window);
 
         if (file != null) {
-            try {
-                FileOutputStream fos = new FileOutputStream(file);
-                fos.write(Exporter.export(pane).getBytes(Charsets.UTF_8));
-                fos.close();
-            } catch (IOException e) {
-                // TODO do something sensible here
-                e.printStackTrace();
-                onSaveAs(actionEvent);
-            }
+            saveTo(file);
+            pane.setCurrentFile(file);
+        }
+    }
+
+    private void saveTo(File file) {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(Exporter.export(pane).getBytes(Charsets.UTF_8));
+            fos.close();
+        } catch (IOException e) {
+            // TODO do something sensible here
+            e.printStackTrace();
         }
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/components/menu/GlobalMenu.java
@@ -1,5 +1,6 @@
 package nl.utwente.group10.ui.components.menu;
 
+import com.google.common.base.Charsets;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.scene.control.ContextMenu;
@@ -7,8 +8,11 @@ import javafx.scene.control.MenuItem;
 import javafx.stage.FileChooser;
 import javafx.stage.Window;
 import nl.utwente.group10.ui.CustomUIPane;
+import nl.utwente.group10.ui.serialize.Exporter;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * A context menu with global actions (i.e. quit).
@@ -59,7 +63,15 @@ public class GlobalMenu extends ContextMenu {
         File file = new FileChooser().showSaveDialog(window);
 
         if (file != null) {
-            /* Save file... */
+            try {
+                FileOutputStream fos = new FileOutputStream(file);
+                fos.write(Exporter.export(pane).getBytes(Charsets.UTF_8));
+                fos.close();
+            } catch (IOException e) {
+                // TODO do something sensible here
+                e.printStackTrace();
+                onSaveAs(actionEvent);
+            }
         }
     }
 

--- a/Code/src/main/java/nl/utwente/group10/ui/serialize/Bundleable.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/serialize/Bundleable.java
@@ -1,0 +1,16 @@
+package nl.utwente.group10.ui.serialize;
+
+import java.util.Map;
+
+/**
+ * Interface for things that can be turned into bundles (maps of strings to
+ * objects), which can in turn be converted into JSON.
+ */
+public interface Bundleable {
+    /**
+     * Serialization function.
+     *
+     * @return a map that describes the bundleable object.
+     */
+    Map<String, Object> toBundle();
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/serialize/Exporter.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/serialize/Exporter.java
@@ -1,0 +1,32 @@
+package nl.utwente.group10.ui.serialize;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import nl.utwente.group10.ui.CustomUIPane;
+
+import java.util.Comparator;
+
+/**
+ * Convert Viskell programs into JSON text.
+ */
+public class Exporter {
+    private Exporter() {
+        // This is a static utility class.
+    }
+
+    /**
+     * Exports the contents of a CustomUIPane into JSON format.
+     *
+     * @param pane The pane to export the children of.
+     * @return a pretty-printed JSON string.
+     */
+    public static String export(CustomUIPane pane) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+        return gson.toJson(pane.getChildren().stream()
+                .filter(n -> n instanceof Bundleable)
+                .sorted(Comparator.comparing(u -> u.getClass().getName()).thenComparing(Object::hashCode))
+                .map(n -> ((Bundleable) n).toBundle())
+                .toArray());
+    }
+}

--- a/Code/src/main/java/nl/utwente/group10/ui/serialize/Importer.java
+++ b/Code/src/main/java/nl/utwente/group10/ui/serialize/Importer.java
@@ -1,0 +1,4 @@
+package nl.utwente.group10.ui.serialize;
+
+public class Importer {
+}

--- a/Code/src/main/resources/ui/InspectorWindow.fxml
+++ b/Code/src/main/resources/ui/InspectorWindow.fxml
@@ -15,6 +15,9 @@
             <Tab closable="false" text="Haskell source">
                 <TextArea fx:id="hs" />
             </Tab>
+            <Tab closable="false" text="JSON serialization">
+                <TextArea fx:id="json" />
+            </Tab>
         </TabPane>
     </center>
     <bottom>


### PR DESCRIPTION
This PR implements the 'Save' and 'Save as' actions. 

The (JavaFX) components are not Java `Serializable`. Instead of using Java's built-in serialization, this PR serializes the program graph to a nicely formatted JSON tree. Components can mark themselves as serializable by implementing the `Bundleable` interface.

The JSON serialization is shown in the Inspector to help with debugging.