### PR TITLE
Add getChildren methods to Lambda and Annotated

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/haskell/expr/Annotated.java
+++ b/Code/src/main/java/nl/utwente/viskell/haskell/expr/Annotated.java
@@ -1,8 +1,11 @@
 package nl.utwente.viskell.haskell.expr;
 
+import com.google.common.collect.ImmutableList;
 import nl.utwente.viskell.haskell.type.HaskellTypeError;
 import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.haskell.type.TypeChecker;
+
+import java.util.List;
 
 /**
  * An Expression be annotated (restricted) by a type, in Haskell notation it is "(expr :: type)".
@@ -42,4 +45,8 @@ public class Annotated extends Expression {
         return this.expr.toString() + " :: " + this.annotation.toString();
     }
 
+    @Override
+    public List<Expression> getChildren() {
+        return ImmutableList.of(expr);
+    }
 }

--- a/Code/src/main/java/nl/utwente/viskell/haskell/expr/Lambda.java
+++ b/Code/src/main/java/nl/utwente/viskell/haskell/expr/Lambda.java
@@ -1,5 +1,6 @@
 package nl.utwente.viskell.haskell.expr;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import nl.utwente.viskell.haskell.type.FunType;
 import nl.utwente.viskell.haskell.type.HaskellTypeError;
@@ -72,4 +73,8 @@ public class Lambda extends Expression {
         return out.toString();
     }
 
+    @Override
+    public List<Expression> getChildren() {
+        return ImmutableList.of(body);
+    }
 }


### PR DESCRIPTION
This makes both expressions introspectable in the inspector window.