### PR TITLE
Split Defintion block into a inner and outer part 

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/CircleMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/CircleMenu.java
@@ -1,9 +1,11 @@
 package nl.utwente.viskell.ui;
 
+import java.util.ArrayList;
+
 import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.StackPane;
+import javafx.scene.input.MouseEvent;
 import javafx.util.Duration;
 import jfxtras.scene.layout.CircularPane;
 import jfxtras.scene.menu.CirclePopupMenu;
@@ -22,11 +24,23 @@ import nl.utwente.viskell.ui.components.Block;
  */
 public class CircleMenu extends CirclePopupMenu {
 
+    /** List of all block on which a CircleMenu is active. */
+    private static ArrayList<Block> activeBlocks = new ArrayList<>();
+    
     /** The context of the menu. */
     private Block block;
 
+    /** Show the Circle menu for a block if not already active. */
+    public static void showFor(Block block, MouseEvent t) {
+        if (! activeBlocks.contains(block)) {
+            activeBlocks.add(block);
+            CircleMenu menu = new CircleMenu(block);
+            menu.show(t);
+        }
+    }
+    
     public CircleMenu(Block block) {
-        super((StackPane) block, null);
+        super(block, null);
         this.block = block;
 
         // Define menu items
@@ -65,6 +79,12 @@ public class CircleMenu extends CirclePopupMenu {
         return image;
     }
 
+    @Override
+    public void hide() {
+        CircleMenu.activeBlocks.remove(this.block);
+        super.hide();
+    }
+    
     /** Copy the {@link Block} in this context. */
     public void copy() {
         // TODO implement clipBoard in main app.

--- a/Code/src/main/java/nl/utwente/viskell/ui/CircleMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/CircleMenu.java
@@ -1,7 +1,5 @@
 package nl.utwente.viskell.ui;
 
-import java.util.ArrayList;
-
 import javafx.scene.control.MenuItem;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -24,19 +22,13 @@ import nl.utwente.viskell.ui.components.Block;
  */
 public class CircleMenu extends CirclePopupMenu {
 
-    /** List of all block on which a CircleMenu is active. */
-    private static ArrayList<Block> activeBlocks = new ArrayList<>();
-    
     /** The context of the menu. */
     private Block block;
 
     /** Show the Circle menu for a block if not already active. */
     public static void showFor(Block block, MouseEvent t) {
-        if (! activeBlocks.contains(block)) {
-            activeBlocks.add(block);
-            CircleMenu menu = new CircleMenu(block);
-            menu.show(t);
-        }
+        CircleMenu menu = new CircleMenu(block);
+        menu.show(t);
     }
     
     public CircleMenu(Block block) {
@@ -79,12 +71,6 @@ public class CircleMenu extends CirclePopupMenu {
         return image;
     }
 
-    @Override
-    public void hide() {
-        CircleMenu.activeBlocks.remove(this.block);
-        super.hide();
-    }
-    
     /** Copy the {@link Block} in this context. */
     public void copy() {
         // TODO implement clipBoard in main app.

--- a/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
@@ -1,13 +1,11 @@
 package nl.utwente.viskell.ui;
 
-import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.input.ScrollEvent;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
 import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
@@ -1,12 +1,8 @@
 package nl.utwente.viskell.ui.components;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javafx.application.Platform;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.value.ObservableValue;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
@@ -39,15 +35,6 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     /** The pane that is used to hold state and place all components on. */
     private CustomUIPane parentPane;
     
-    /** The Circle (Context) menu associated with this block instance. */
-    private CircleMenu circleMenu;
-    
-    /** The local expression of this Block. */
-    protected Expression localExpr;
-    
-    /** Property for the whether the visuals are up to date. */
-    protected BooleanProperty staleVisuals;
-    
     /** Whether the anchor types are fresh*/
     private boolean freshAnchorTypes;
     
@@ -59,11 +46,8 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
      */
     public Block(CustomUIPane pane) {
         this.parentPane = pane;
-        this.staleVisuals = new SimpleBooleanProperty(false);
         this.freshAnchorTypes = false;
         this.updateInProgress = false;
-        
-        this.staleVisuals.addListener(this::fixupVisualState);
         
         // Visually react on selection.
         this.parentPane.selectedBlockProperty().addListener(event -> {
@@ -84,11 +68,7 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     private void handleMouseEvent(MouseEvent t) {
         parentPane.setSelectedBlock(this);
         if (t.getButton() == MouseButton.SECONDARY) {
-            if (this.circleMenu == null) {
-                this.circleMenu = new CircleMenu(this);
-            }
-            
-            this.circleMenu.show(t);
+            CircleMenu.showFor(this, t);
         }
     }
 
@@ -100,17 +80,13 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     /**
      * @return All InputAnchors of the block.
      */
-    public List<InputAnchor> getAllInputs() {
-        return ImmutableList.of();
-    }
+    public abstract List<InputAnchor> getAllInputs();
 
     /**
      * @return the optional output Anchor for this Block
      * TODO generalize to List<OutputAnchor> getOutputAnchors()
      */
-    public Optional<OutputAnchor> getOutputAnchor() {
-        return Optional.empty();
-    }
+    public abstract Optional<OutputAnchor> getOutputAnchor();
     
     /** @return true if no connected output anchor exist */
     public boolean isBottomMost() {
@@ -169,33 +145,25 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
             input.getConnection().ifPresent(c -> c.handleConnectionChangesUpwards(finalPhase));
         }
         
-        // after type checking all input in the first phase, refresh the local expression of this block
-        if (!finalPhase) {
-            this.updateExpr();
-        }
-
         // propagate changes down from the output anchor to connected inputs
         this.getOutputAnchor().ifPresent(a -> a.getOppositeAnchors().stream().forEach(x -> x.handleConnectionChanges(finalPhase)));
 
-        // If the change is not propagated any further down start recomputation.
-        if (finalPhase && this.isBottomMost()) {
-            // Now that the expressions and types are updated, initiate a visual refresh.
-            Platform.runLater(() -> this.staleVisuals.set(true));
+        if (finalPhase) {
+            // Now that the expressions and types are fully updated, initiate a visual refresh.
+            Platform.runLater(() -> this.invalidateVisualState());
         }
     }
     
     /**
      * @return The local expression this Block represents.
      */
-    public final Expression getLocalExpr() {
-        return this.localExpr;
-    }
+    public abstract Expression getLocalExpr();
     
     /**
      * @return A complete expression of this block and all its dependencies.
      */
     public final Expression getFullExpr() {
-        LetExpression fullExpr = new LetExpression(this.localExpr);
+        LetExpression fullExpr = new LetExpression(this.getLocalExpr());
         this.extendExprGraph(fullExpr);
         return fullExpr;
     }
@@ -211,31 +179,10 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     }
     
     /**
-     * Updates the expression
-     */
-    public abstract void updateExpr();
-    
-    /**
      * Called when the VisualState changed.
      */
     public abstract void invalidateVisualState();
     
-    /**
-     * ChangeListener that resolves outdated visuals and 
-     * propagates visual update requirements upwards.
-     */
-    private void fixupVisualState(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newStale) {
-        if (newStale) {
-            this.invalidateVisualState();
-        
-            for (InputAnchor input : this.getAllInputs()) {
-                input.getOppositeAnchor().ifPresent(a -> a.invalidateVisualState());
-            }
-            
-            this.staleVisuals.setValue(false);
-        }
-    }
-
     /**
      * @return class-specific properties of this Block.
      */

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
@@ -102,18 +102,6 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     }
     
     /**
-     * Handle the expression and types changes caused by modified connections or values.
-     * @param finalPhase whether the change propagation is in the second (final) phase.
-     */
-    public final void handleConnectionChanges(boolean finalPhase) {
-        if (! finalPhase) {
-            this.prepareConnectionChanges();
-        }
-        
-        this.propagateConnectionChanges(finalPhase);
-    }
-    
-    /**
      * Connection change preparation; set fresh types in all anchors. 
      */
     public final void prepareConnectionChanges() {
@@ -130,13 +118,20 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
     protected abstract void refreshAnchorTypes();
     
     /**
-     * Propagate the changes through connected blocks, then trigger a visual update.
+     * Handle the expression and types changes caused by modified connections or values.
+     * Propagate the changes through connected blocks, and if final phase trigger a visual update.
      * @param finalPhase whether the change propagation is in the second (final) phase.
      */
-    protected void propagateConnectionChanges(boolean finalPhase) {
+    public void handleConnectionChanges(boolean finalPhase) {
         if (this.updateInProgress != finalPhase) {
             return; // avoid doing extra work and infinite recursion
         }
+
+        if (! finalPhase) {
+            // in first phase ensure that anchor types are refreshed
+            this.prepareConnectionChanges();
+        }
+        
         this.updateInProgress = !finalPhase;
         this.freshAnchorTypes = false;
         

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
@@ -21,10 +21,13 @@ import com.google.common.collect.ImmutableList;
  */
 public class DefinitionBlock extends Block implements ComponentLoader {
 
+    /** the area in which the function anchor is in */
     @FXML private Pane funSpace;
 
+    /* The label with the explicit name and type of this definition, if it has one. */
     @FXML private Label signature;
 
+    /** The internal lambda within this definition block */
     private LambdaContainer body;
     
     /** The function anchor (second bottom anchor) */

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
@@ -3,22 +3,16 @@ package nl.utwente.viskell.ui.components;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane;
-import nl.utwente.viskell.haskell.expr.Annotated;
 import nl.utwente.viskell.haskell.expr.Binder;
 import nl.utwente.viskell.haskell.expr.Expression;
-import nl.utwente.viskell.haskell.expr.Lambda;
-import nl.utwente.viskell.haskell.expr.LetExpression;
-import nl.utwente.viskell.haskell.type.FunType;
 import nl.utwente.viskell.haskell.type.Type;
-import nl.utwente.viskell.haskell.type.TypeScope;
 import nl.utwente.viskell.ui.ComponentLoader;
 import nl.utwente.viskell.ui.CustomUIPane;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 
@@ -27,61 +21,12 @@ import com.google.common.collect.ImmutableList;
  */
 public class DefinitionBlock extends Block implements ComponentLoader {
 
-    // TODO make this an independent class if other blocks (case?) need this too 
-    /** An internal output anchor for an argument binder. */
-    public static class BinderAnchor extends OutputAnchor {
-
-        public BinderAnchor(DefinitionBlock parent, Binder binder) {
-            super(parent, binder);
-        }
-
-        @Override
-        protected void extendExprGraph(LetExpression exprGraph) {
-            return; // the scope of graph is limited its parent
-        }
-    }
-
-    // TODO make this an independent class if other blocks (case?) need this too
-    /** An internal input anchor for a local result. */
-    public static class ResultAnchor extends InputAnchor {
-        /** The optional type of the result of the function (the last part of the signature). */
-        private final Optional<Type> resType;
-
-        public ResultAnchor(DefinitionBlock parent, Optional<Type> resType) {
-            super(parent);
-            this.resType = resType;
-        }
-        
-        @Override
-        public Expression getLocalExpr() {
-            if (this.resType.isPresent()) {
-                return new Annotated(super.getLocalExpr(), this.resType.get());
-            }
-           
-            return super.getLocalExpr();
-        }
-        
-        /** Set fresh type for the next typechecking cycle.*/
-        private void refreshAnchorType(TypeScope scope) {
-            if (this.resType.isPresent()) {
-                this.setFreshRequiredType(this.resType.get(), scope);
-            } else {
-                this.setFreshRequiredType(TypeScope.unique("y"), scope);
-            }
-        }
-    }
-    
-    @FXML private Pane argSpace;
-    @FXML private Pane resSpace;
     @FXML private Pane funSpace;
 
     @FXML private Label signature;
 
-    private List<BinderAnchor> args;
-
-    /** The result anchor (first bottom anchor) */
-    private ResultAnchor res;
-
+    private LambdaContainer body;
+    
     /** The function anchor (second bottom anchor) */
     private OutputAnchor fun;
 
@@ -96,37 +41,30 @@ public class DefinitionBlock extends Block implements ComponentLoader {
 
         this.signature.setText("");
         this.signature.setVisible(false);
-        this.args = new ArrayList<>();
-        for (int i = 0; i < arity; i++) {
-            this.args.add(new BinderAnchor(this, new Binder("x_" + i)));
-        }
-        this.res = new ResultAnchor(this, Optional.empty());
-        this.setupAnchors();
+        
+        this.body = new LambdaContainer(this, arity);
+        ((VBox)this.getChildren().get(0)).getChildren().add(1, this.body);
+        
+        this.fun = new OutputAnchor(this, new Binder("lam"));
+        this.funSpace.getChildren().add(this.fun);
+        TactilePane.setGoToForegroundOnContact(this, false);
     }
             
+    /**
+     * Constructs a DefinitionBlock with an explicitly type function.
+     * @param pane the parent ui pane.
+     * @param name of the function.
+     * @param type the full function type.
+     */
     public DefinitionBlock(CustomUIPane pane, String name, Type type) {
         super(pane);
         this.loadFXML("DefinitionBlock");
 
-        this.args = new ArrayList<>();
         this.signature.setText(name + " :: " + type.prettyPrint());
-        // Collect argument types and result type
-        Type t = type;
-        int i = 0;
-        while (t instanceof FunType) {
-            FunType ft = (FunType) t;
-            args.add(new BinderAnchor(this, new Binder(name + "_x" + i, ft.getArgument())));
-            i++;
-            t = ft.getResult();
-        }
-        this.res = new ResultAnchor(this, Optional.of(t));
 
-        this.setupAnchors();
-    }
-
-    private void setupAnchors() {
-        this.argSpace.getChildren().addAll(this.args);
-        this.resSpace.getChildren().add(this.res);
+        this.body = new LambdaContainer(this, name, type);
+        ((VBox)this.getChildren().get(0)).getChildren().add(1, this.body);
+        
         this.fun = new OutputAnchor(this, new Binder("lam"));
         this.funSpace.getChildren().add(this.fun);
         TactilePane.setGoToForegroundOnContact(this, false);
@@ -144,32 +82,16 @@ public class DefinitionBlock extends Block implements ComponentLoader {
 
     @Override
     public void refreshAnchorTypes() {
-        TypeScope scope = new TypeScope();
-        for (BinderAnchor arg : this.args) {
-            arg.refreshType(scope);
-        }
-        this.res.refreshAnchorType(scope);
-        
-        ArrayList<Type> types = new ArrayList<>();
-        for (BinderAnchor arg : this.args) {
-            types.add(arg.getType());
-        }
-        types.add(this.res.getType());
+        // do typechecking internal connections first so that the lambda type is inferred
+        this.body.handleConnectionChanges(false);
 
-        this.fun.setExactRequiredType(Type.fun(types.toArray(new Type[this.args.size()+1])));
+        this.fun.setExactRequiredType(this.body.getLambdaType().getFresh());
     }
 
     @Override
     protected void propagateConnectionChanges(boolean finalPhase) {
-        // first propagate into the internal blocks
-        this.res.getConnection().ifPresent(c -> c.handleConnectionChangesUpwards(finalPhase));
-
-        // also propagate in from above in case the lambda is partially connected 
-        for (BinderAnchor arg : this.args) {
-            for (InputAnchor anchor : arg.getOppositeAnchors()) {
-                anchor.handleConnectionChanges(finalPhase);
-            }
-        }
+        // first propagate into the internals
+        this.body.handleConnectionChanges(finalPhase);
 
         // continue as normal with propagating changes on the outside
         super.propagateConnectionChanges(finalPhase);
@@ -177,16 +99,13 @@ public class DefinitionBlock extends Block implements ComponentLoader {
     
     @Override
     public final Expression getLocalExpr() {
-        List<Binder> binders = this.args.stream().map(arg -> arg.binder).collect(Collectors.toList());
-        LetExpression body = new LetExpression(this.res.getLocalExpr());
-        this.res.extendExprGraph(body);
-        return new Lambda(binders, body);
+        return this.body.getLocalExpr();
     }
 
     @Override
     public void invalidateVisualState() {
-        // also update the internal blocks connected to the internal anchor 
-        this.res.getOppositeAnchor().ifPresent(a -> a.invalidateVisualState());
+        this.body.invalidateVisualState();
+        // TODO update fun anchor when it gets a type label
     }
 
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * A definition block is a block that represents a named lambda. It can be used to build lambda abstractions.
  */
@@ -131,6 +133,11 @@ public class DefinitionBlock extends Block implements ComponentLoader {
     }
 
     @Override
+    public List<InputAnchor> getAllInputs() {
+        return ImmutableList.of();
+    }
+
+    @Override
     public Optional <OutputAnchor> getOutputAnchor() {
         return Optional.of(this.fun);
     }
@@ -169,11 +176,11 @@ public class DefinitionBlock extends Block implements ComponentLoader {
     }
     
     @Override
-    public final void updateExpr() {
+    public final Expression getLocalExpr() {
         List<Binder> binders = this.args.stream().map(arg -> arg.binder).collect(Collectors.toList());
         LetExpression body = new LetExpression(this.res.getLocalExpr());
         this.res.extendExprGraph(body);
-        this.localExpr = new Lambda(binders, body);
+        return new Lambda(binders, body);
     }
 
     @Override
@@ -181,4 +188,5 @@ public class DefinitionBlock extends Block implements ComponentLoader {
         // also update the internal blocks connected to the internal anchor 
         this.res.getOppositeAnchor().ifPresent(a -> a.invalidateVisualState());
     }
+
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DefinitionBlock.java
@@ -91,13 +91,12 @@ public class DefinitionBlock extends Block implements ComponentLoader {
         this.fun.setExactRequiredType(this.body.getLambdaType().getFresh());
     }
 
-    @Override
-    protected void propagateConnectionChanges(boolean finalPhase) {
+    public void handleConnectionChanges(boolean finalPhase) {
         // first propagate into the internals
         this.body.handleConnectionChanges(finalPhase);
 
         // continue as normal with propagating changes on the outside
-        super.propagateConnectionChanges(finalPhase);
+        super.handleConnectionChanges(finalPhase);
     }
     
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
@@ -10,6 +10,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.TilePane;
 import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;
+import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.type.TypeScope;
 import nl.utwente.viskell.ui.CustomUIPane;
 
@@ -109,8 +110,13 @@ public class DisplayBlock extends Block {
     }
 
     @Override
-    public void updateExpr() {
-        this.localExpr = inputAnchor.getLocalExpr();
+    public Optional<OutputAnchor> getOutputAnchor() {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Expression getLocalExpr() {
+        return inputAnchor.getLocalExpr();
     }
     
     @Override
@@ -122,4 +128,5 @@ public class DisplayBlock extends Block {
     public String toString() {
         return "DisplayBlock[" + getOutput() + "]";
     }
+
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/FunctionBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/FunctionBlock.java
@@ -11,6 +11,7 @@ import javafx.scene.layout.Region;
 import nl.utwente.viskell.haskell.env.FunctionInfo;
 import nl.utwente.viskell.haskell.expr.Apply;
 import nl.utwente.viskell.haskell.expr.Binder;
+import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.expr.FunVar;
 import nl.utwente.viskell.haskell.type.FunType;
 import nl.utwente.viskell.haskell.type.Type;
@@ -140,11 +141,13 @@ public class FunctionBlock extends Block {
     }
 
     @Override
-    public final void updateExpr() {
-        this.localExpr = new FunVar(this.funInfo);
+    public Expression getLocalExpr() {
+        Expression expr = new FunVar(this.funInfo);
         for (InputAnchor in : this.getActiveInputs()) {
-            this.localExpr = new Apply(this.localExpr, in.getLocalExpr());
+            expr = new Apply(expr, in.getLocalExpr());
         }
+        
+        return expr;
     }
     
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;
+import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.type.FunType;
 import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.haskell.type.TypeScope;
@@ -21,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 /**
  * Block that accepts a (Float -> Float) function to be displayed on a linechart
@@ -64,10 +66,15 @@ public class GraphBlock extends Block {
     public List<InputAnchor> getAllInputs() {
         return ImmutableList.of(input);
     }
+
+    @Override
+    public Optional<OutputAnchor> getOutputAnchor() {
+        return Optional.empty();
+    }
     
     @Override
-    public void updateExpr() {
-        this.localExpr = input.getLocalExpr();
+    public Expression getLocalExpr() {
+        return input.getLocalExpr();
     }
 
     @Override
@@ -109,4 +116,5 @@ public class GraphBlock extends Block {
 
         chart.setData(lineChartData);
     }
+
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
@@ -1,0 +1,233 @@
+package nl.utwente.viskell.ui.components;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.Pane;
+import nl.utwente.viskell.haskell.expr.Annotated;
+import nl.utwente.viskell.haskell.expr.Binder;
+import nl.utwente.viskell.haskell.expr.Expression;
+import nl.utwente.viskell.haskell.expr.Lambda;
+import nl.utwente.viskell.haskell.expr.LetExpression;
+import nl.utwente.viskell.haskell.type.FunType;
+import nl.utwente.viskell.haskell.type.Type;
+import nl.utwente.viskell.haskell.type.TypeScope;
+import nl.utwente.viskell.ui.ComponentLoader;
+
+public class LambdaContainer extends BorderPane implements ComponentLoader {
+
+    // TODO make this an independent class if other blocks (case?) need this too 
+    /** An internal output anchor for an argument binder. */
+    public class BinderAnchor extends OutputAnchor {
+
+        // FIXME BinderAnchor should not have or use the DefinitionBlock parent
+        public BinderAnchor(DefinitionBlock parent, Binder binder) {
+            super(parent, binder);
+        }
+
+        @Override
+        protected void extendExprGraph(LetExpression exprGraph) {
+            return; // the scope of graph is limited its parent
+        }
+        
+        @Override
+        public void initiateConnectionChanges() {
+            // Starts a new (2 phase) change propagation process from this lambda.
+            LambdaContainer.this.handleConnectionChanges(false);
+            LambdaContainer.this.handleConnectionChanges(true);
+        }
+
+        @Override
+        public void prepareConnectionChanges() {
+            LambdaContainer.this.refreshAnchorTypes();
+        }
+
+        @Override
+        protected void handleConnectionChanges(boolean finalPhase) {
+            LambdaContainer.this.handleConnectionChanges(finalPhase);
+        }
+    }
+
+    // TODO make this an independent class if other blocks (case?) need this too
+    /** An internal input anchor for a local result. */
+    public class ResultAnchor extends InputAnchor {
+        /** The optional type of the result of the function (the last part of the signature). */
+        private final Optional<Type> resType;
+        
+        // FIXME ResultAnchor should not have or use the DefinitionBlock parent
+        public ResultAnchor(DefinitionBlock parent, Optional<Type> resType) {
+            super(parent);
+            this.resType = resType;
+        }
+        
+        @Override
+        public Expression getLocalExpr() {
+            if (this.resType.isPresent()) {
+                return new Annotated(super.getLocalExpr(), this.resType.get());
+            }
+           
+            return super.getLocalExpr();
+        }
+        
+        /** Set fresh type for the next typechecking cycle.*/
+        private void refreshAnchorType(TypeScope scope) {
+            if (this.resType.isPresent()) {
+                this.setFreshRequiredType(this.resType.get(), scope);
+            } else {
+                this.setFreshRequiredType(TypeScope.unique("y"), scope);
+            }
+        }
+
+        @Override
+        protected void handleConnectionChanges(boolean finalPhase) {
+            LambdaContainer.this.handleConnectionChanges(finalPhase);
+        }
+    }
+    
+    /* area containing argument anchors */
+    @FXML private Pane argSpace;
+    
+    /* area contain result anchor */
+    @FXML private Pane resSpace;
+
+    /* The */
+    private DefinitionBlock wrapper;
+    
+    /* The lambda argument anchors */
+    private List<BinderAnchor> args;
+
+    /** The result anchor */
+    private ResultAnchor res;
+
+    /** Whether the anchor types are fresh*/
+    private boolean freshAnchorTypes;
+    
+    /** Status of change updating process in this block. */
+    private boolean updateInProgress;
+
+    /**
+     * Constructs a LambdaContainer for an untyped lambda of n arguments.
+     * @param arity the number of arguments of this lambda.
+     */
+    public LambdaContainer(DefinitionBlock wrapper, int arity) {
+        super();
+        this.loadFXML("LambdaContainer");
+        this.wrapper = wrapper;
+        
+        this.args = new ArrayList<>();
+        for (int i = 0; i < arity; i++) {
+            this.args.add(this.new BinderAnchor(wrapper, new Binder("x_" + i)));
+        }
+        this.res = this.new ResultAnchor(wrapper, Optional.empty());
+        
+        this.argSpace.getChildren().addAll(this.args);
+        this.resSpace.getChildren().add(this.res);
+    }
+    
+    /**
+     * Constructs a LambdaContainer with explicit types.
+     * @param name of the function.
+     * @param type the full function type.
+     */
+    public LambdaContainer(DefinitionBlock wrapper, String name, Type type) {
+        super();
+        this.loadFXML("LambdaContainer");
+        this.wrapper = wrapper;
+
+        // Collect argument types and result type
+        this.args = new ArrayList<>();
+        Type t = type;
+        int i = 0;
+        while (t instanceof FunType) {
+            FunType ft = (FunType) t;
+            args.add(this.new BinderAnchor(wrapper, new Binder(name + "_x" + i, ft.getArgument())));
+            i++;
+            t = ft.getResult();
+        }
+        this.res = this.new ResultAnchor(wrapper, Optional.of(t));
+
+        this.argSpace.getChildren().addAll(this.args);
+        this.resSpace.getChildren().add(this.res);
+    }
+
+    /** Set fresh types in all anchors of this lambda for the next typechecking cycle. */
+    protected void refreshAnchorTypes() {
+        if (this.updateInProgress || this.freshAnchorTypes) {
+            return; // refresh anchor types only once
+        }
+        this.freshAnchorTypes = true;
+        
+        TypeScope scope = new TypeScope();
+        for (BinderAnchor arg : this.args) {
+            arg.refreshType(scope);
+        }
+        this.res.refreshAnchorType(scope);
+    }
+    
+    /** returns the current (inferred) type of this lambda */
+    protected Type getLambdaType() {
+        ArrayList<Type> types = new ArrayList<>();
+        for (BinderAnchor arg : this.args) {
+            types.add(arg.getType());
+        }
+        types.add(this.res.getType());
+
+        return Type.fun(types.toArray(new Type[this.args.size()+1]));
+    }
+    
+    /**
+     * Handle the expression and types changes caused by modified connections or values.
+     * @param finalPhase whether the change propagation is in the second (final) phase.
+     */
+    public final void handleConnectionChanges(boolean finalPhase) {
+        if (! finalPhase) {
+            this.refreshAnchorTypes();
+        }
+        this.propagateConnectionChanges(finalPhase);
+    }
+    
+    /**
+     * Propagate the changes through connected blocks, then trigger a visual update.
+     * @param finalPhase whether the change propagation is in the second (final) phase.
+     */
+    private void propagateConnectionChanges(boolean finalPhase) {
+        if (this.updateInProgress != finalPhase) {
+            return; // avoid doing extra work and infinite recursion
+        }
+        this.updateInProgress = !finalPhase;
+        this.freshAnchorTypes = false;
+        
+        // first propagate up from the result anchor
+        this.res.getConnection().ifPresent(c -> c.handleConnectionChangesUpwards(finalPhase));
+
+        // also propagate in from above in case the lambda is partially connected 
+        for (BinderAnchor arg : this.args) {
+            for (InputAnchor anchor : arg.getOppositeAnchors()) {
+                anchor.handleConnectionChanges(finalPhase);
+                // take the type of argument connections in account even if the connected block is being processed
+                anchor.getConnection().ifPresent(c -> c.handleConnectionChangesUpwards(finalPhase));
+            }
+        }
+
+        // propagate internal type changes outwards
+        this.wrapper.handleConnectionChanges(finalPhase);
+    }
+    
+    /** @return The local expression this LambdaContainer represents. */
+    public Expression getLocalExpr() {
+        List<Binder> binders = this.args.stream().map(arg -> arg.binder).collect(Collectors.toList());
+        LetExpression body = new LetExpression(this.res.getLocalExpr());
+        this.res.extendExprGraph(body);
+        return new Lambda(binders, body);
+    }
+
+    /** Called when the VisualState changed. */
+    public void invalidateVisualState() {
+        // TODO update anchors when they get a type label       
+    }
+    
+}

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
@@ -182,23 +182,19 @@ public class LambdaContainer extends BorderPane implements ComponentLoader {
     
     /**
      * Handle the expression and types changes caused by modified connections or values.
+     * Also propagate the changes through internal connected blocks, and then outwards.
      * @param finalPhase whether the change propagation is in the second (final) phase.
      */
     public final void handleConnectionChanges(boolean finalPhase) {
-        if (! finalPhase) {
-            this.refreshAnchorTypes();
-        }
-        this.propagateConnectionChanges(finalPhase);
-    }
-    
-    /**
-     * Propagate the changes through connected blocks, then trigger a visual update.
-     * @param finalPhase whether the change propagation is in the second (final) phase.
-     */
-    private void propagateConnectionChanges(boolean finalPhase) {
         if (this.updateInProgress != finalPhase) {
             return; // avoid doing extra work and infinite recursion
         }
+        
+        if (! finalPhase) {
+            // in first phase ensure that anchor types are refreshed
+            this.refreshAnchorTypes();
+        }
+        
         this.updateInProgress = !finalPhase;
         this.freshAnchorTypes = false;
         

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
@@ -18,6 +18,7 @@ import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.haskell.type.TypeScope;
 import nl.utwente.viskell.ui.ComponentLoader;
 
+/** Represent a lambda construct with internal anchor and blocks */
 public class LambdaContainer extends BorderPane implements ComponentLoader {
 
     // TODO make this an independent class if other blocks (case?) need this too 
@@ -94,7 +95,7 @@ public class LambdaContainer extends BorderPane implements ComponentLoader {
     /* area contain result anchor */
     @FXML private Pane resSpace;
 
-    /* The */
+    /* The definition block this lambda is contained by. */
     private DefinitionBlock wrapper;
     
     /* The lambda argument anchors */

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/OutputAnchor.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/OutputAnchor.java
@@ -143,7 +143,7 @@ public class OutputAnchor extends ConnectionAnchor {
     
     /** invalidates the visual state of the block this anchor belongs to*/
     public void invalidateVisualState() {
-        this.block.staleVisuals.set(true);
+        this.block.invalidateVisualState();
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/ValueBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/ValueBlock.java
@@ -1,5 +1,6 @@
 package nl.utwente.viskell.ui.components;
 
+import java.util.List;
 import java.util.Optional;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -7,11 +8,13 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import nl.utwente.viskell.haskell.expr.Binder;
+import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.expr.Value;
 import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.haskell.type.TypeScope;
 import nl.utwente.viskell.ui.CustomUIPane;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -77,8 +80,8 @@ public class ValueBlock extends Block {
     }
     
     @Override
-    public void updateExpr() {
-        this.localExpr = new Value(this.output.getType(), getValue());
+    public Expression getLocalExpr() {
+        return new Value(this.output.getType(), getValue());
     }
 
     @Override
@@ -86,6 +89,11 @@ public class ValueBlock extends Block {
         this.output.refreshType(new TypeScope());
     }
 
+    @Override
+    public List<InputAnchor> getAllInputs() {
+        return ImmutableList.of();
+    }
+    
     @Override
     public Optional<OutputAnchor> getOutputAnchor() {
         return Optional.of(output);

--- a/Code/src/main/resources/ui/DefinitionBlock.fxml
+++ b/Code/src/main/resources/ui/DefinitionBlock.fxml
@@ -5,11 +5,12 @@
 <fx:root type="nl.utwente.viskell.ui.components.DefinitionBlock" xmlns:fx="http://javafx.com/fxml/">
     <VBox>
         <Label fx:id="signature" styleClass="signature" />
+        <!-- The internal LambdaContainer will be inserted here. -->
         <VBox>
             <padding>
                 <Insets bottom="10.0" left="10.0" right ="10.0" top="10.0"/>
             </padding>
-            <FlowPane fx:id="funSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="BOTTOM_LEFT"/>
+            <HBox fx:id="funSpace" spacing="50" alignment="BOTTOM_LEFT"/>
         </VBox>
     </VBox>
 </fx:root>

--- a/Code/src/main/resources/ui/DefinitionBlock.fxml
+++ b/Code/src/main/resources/ui/DefinitionBlock.fxml
@@ -5,30 +5,6 @@
 <fx:root type="nl.utwente.viskell.ui.components.DefinitionBlock" xmlns:fx="http://javafx.com/fxml/">
     <VBox>
         <Label fx:id="signature" styleClass="signature" />
-        <BorderPane styleClass="def">
-            <top>
-                <VBox>
-                    <padding>
-                        <Insets bottom="10.0" left="10.0" right ="10.0" top="10.0"/>
-                    </padding>
-
-                    <FlowPane fx:id="argSpace" prefWrapLength="100" vgap="50" hgap="50" alignment="BOTTOM_LEFT"/>
-                </VBox>
-            </top>
-            <center>
-                <Pane prefWidth="400" prefHeight="400">
-                </Pane>
-            </center>
-            <bottom>
-                <VBox>
-                    <padding>
-                        <Insets bottom="10.0" left="10.0" right ="10.0" top="10.0"/>
-                    </padding>
-
-                    <FlowPane fx:id="resSpace" prefWrapLength="100" vgap="50" hgap="10" alignment="BOTTOM_LEFT"/>
-                </VBox>
-            </bottom>
-        </BorderPane>
         <VBox>
             <padding>
                 <Insets bottom="10.0" left="10.0" right ="10.0" top="10.0"/>

--- a/Code/src/main/resources/ui/LambdaContainer.fxml
+++ b/Code/src/main/resources/ui/LambdaContainer.fxml
@@ -7,9 +7,7 @@
 			<padding>
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</padding>
-
-			<FlowPane fx:id="argSpace" prefWrapLength="100" vgap="50"
-				hgap="50" alignment="BOTTOM_LEFT" />
+			<HBox fx:id="argSpace" spacing="50" alignment="CENTER" />
 		</VBox>
 	</top>
 	<center>
@@ -21,9 +19,7 @@
 			<padding>
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</padding>
-
-			<FlowPane fx:id="resSpace" prefWrapLength="100" vgap="50"
-				hgap="10" alignment="BOTTOM_LEFT" />
+			<HBox fx:id="resSpace" spacing="50" alignment="CENTER" />
 		</VBox>
 	</bottom>
 </fx:root>

--- a/Code/src/main/resources/ui/LambdaContainer.fxml
+++ b/Code/src/main/resources/ui/LambdaContainer.fxml
@@ -1,0 +1,29 @@
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.*?>
+<?import nl.utwente.viskell.ui.components.LambdaContainer?>
+<fx:root type="nl.utwente.viskell.ui.components.LambdaContainer" xmlns:fx="http://javafx.com/fxml/" styleClass="def">
+	<top>
+		<VBox>
+			<padding>
+				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+			</padding>
+
+			<FlowPane fx:id="argSpace" prefWrapLength="100" vgap="50"
+				hgap="50" alignment="BOTTOM_LEFT" />
+		</VBox>
+	</top>
+	<center>
+		<Pane prefWidth="400" prefHeight="400">
+		</Pane>
+	</center>
+	<bottom>
+		<VBox>
+			<padding>
+				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+			</padding>
+
+			<FlowPane fx:id="resSpace" prefWrapLength="100" vgap="50"
+				hgap="10" alignment="BOTTOM_LEFT" />
+		</VBox>
+	</bottom>
+</fx:root>

--- a/Code/src/main/resources/ui/LambdaContainer.fxml
+++ b/Code/src/main/resources/ui/LambdaContainer.fxml
@@ -7,7 +7,7 @@
 			<padding>
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</padding>
-			<HBox fx:id="argSpace" spacing="50" alignment="CENTER" />
+			<HBox fx:id="argSpace" spacing="50" alignment="CENTER_LEFT" />
 		</VBox>
 	</top>
 	<center>
@@ -19,7 +19,7 @@
 			<padding>
 				<Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
 			</padding>
-			<HBox fx:id="resSpace" spacing="50" alignment="CENTER" />
+			<HBox fx:id="resSpace" spacing="50" alignment="CENTER_LEFT" />
 		</VBox>
 	</bottom>
 </fx:root>


### PR DESCRIPTION
Also types now only propagate outwards from a lambda.
Depends on #260.