### PR TITLE
Make GhciSession a Service that returns Futures

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ghcj/GhciSession.java
+++ b/Code/src/main/java/nl/utwente/viskell/ghcj/GhciSession.java
@@ -1,21 +1,35 @@
 package nl.utwente.viskell.ghcj;
 
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import nl.utwente.viskell.haskell.env.Environment;
 import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.ui.Main;
 
-import java.io.Closeable;
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.prefs.Preferences;
 
 /**
  * A conversation with an instance of ghci.
+ *
+ * Public methods are safe to use from multiple threads.
  */
-public final class GhciSession implements Closeable {
+public final class GhciSession extends AbstractExecutionThreadService {
+    /** Work queue. */
+    private ArrayBlockingQueue<AbstractMap.SimpleEntry<String, SettableFuture<String>>> queue;
+
+    /** Stuff this into the work queue to stop running. */
+    private final static String POISON = null;
+
     /** The evaluator this GhciSession will communicate with. */
     private Evaluator ghci;
 
@@ -31,35 +45,50 @@ public final class GhciSession implements Closeable {
      *         or does not understand our setup sequence.
      */
     public GhciSession() throws HaskellException {
-        start();
+        super();
+
+        queue = new ArrayBlockingQueue<>(1024);
+    }
+
+    @Override
+    protected void run() throws Exception {
+        while (true) {
+            AbstractMap.SimpleEntry<String, SettableFuture<String>> x = queue.take();
+
+            String expr = x.getKey();
+            SettableFuture<String> future = x.getValue();
+
+            if (Objects.equals(expr, POISON)) {
+                // Something wants us to quit - do so.
+                break;
+            } else {
+                try {
+                    String result = this.ghci.eval(expr);
+                    future.set(result.trim());
+                } catch (HaskellException e) {
+                    future.setException(e);
+                }
+            }
+        }
     }
 
     /**
      * Uploads a new let binding to ghci
      * @param name The name of the new function.
      * @param func The actual function.
-     * @throws HaskellException when the function is rejected by ghci.
      */
-    public void push(final String name, final Expression func) throws HaskellException {
-        try {
-            this.ghci.eval(String.format("let %s = %s", name, func.toHaskell()));
-        } catch (HaskellException e) {
-            throw new HaskellException(e.getMessage(), func);
-        }
+    public ListenableFuture<String> push(final String name, final Expression func) {
+        String let = String.format("let %s = %s", name, func.toHaskell());
+        return pullRaw(let);
     }
 
     /**
      * Returns the result of evaluating a Haskell expression.
      * @param expr The expression to evaluate.
      * @return The result of the evaluation.
-     * @throws HaskellException when ghci encountered an error.
      */
-    public String pull(final Expression expr) throws HaskellException {
-        try {
-            return this.ghci.eval(expr.toHaskell()).trim();
-        } catch (HaskellException e) {
-            throw new HaskellException(e.getMessage(), expr);
-        }
+    public ListenableFuture<String> pull(final Expression expr) {
+        return pullRaw(expr.toHaskell());
     }
 
     /**
@@ -67,10 +96,18 @@ public final class GhciSession implements Closeable {
      * Should only be used for testing purposes or for a known valid Haskell expression. 
      * @param expr The string representation of the expression to evaluate.
      * @return The result of the evaluation.
-     * @throws HaskellException when ghci encountered an error.
      */
-    public String pullRaw(final String expr) throws HaskellException {
-        return this.ghci.eval(expr).trim();
+    public ListenableFuture<String> pullRaw(final String expr) {
+        SettableFuture<String> result = SettableFuture.create();
+        AbstractMap.SimpleEntry<String, SettableFuture<String>> entry = new AbstractMap.SimpleEntry<>(expr, result);
+
+        try {
+            queue.put(entry);
+        } catch (InterruptedException e) {
+            result.setException(e);
+        }
+
+        return result;
     }
     
     /**
@@ -81,14 +118,24 @@ public final class GhciSession implements Closeable {
      * @throws HaskellException when  ghci encountered an error or the type could not be parsed.
      */
     public Type pullType(final String expr, Environment env) throws HaskellException {
-        String[] parts = this.pullRaw(":t " + expr).split(" :: ");
-        if (parts.length < 2) {
-            throw new HaskellException("ghci could not determine the type of:\n" + expr);
+        try {
+            String[] parts = this.pullRaw(":t " + expr).get().split(" :: ");
+
+            if (parts.length < 2) {
+                throw new HaskellException("ghci could not determine the type of:\n" + expr);
+            }
+
+            return env.buildType(parts[1].trim());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new HaskellException(e);
         }
-            
-        return env.buildType(parts[1].trim());
     }
-    
+
+    @Override
+    protected void triggerShutdown() {
+        queue.offer(new AbstractMap.SimpleEntry<>(POISON, null));
+    }
+
     /**
      * @return a String representation of this GhciSession.
      */
@@ -97,7 +144,7 @@ public final class GhciSession implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void shutDown() throws IOException {
         try {
             this.ghci.close();
             this.ghci = null;
@@ -107,7 +154,8 @@ public final class GhciSession implements Closeable {
     }
 
     /** Build a new Evaluator, closing the old one if it exists. */
-    public void start() throws HaskellException {
+    @Override
+    public void startUp() throws HaskellException {
         if (this.ghci != null) {
             this.ghci.close();
         }

--- a/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
@@ -53,6 +53,7 @@ public class CustomUIPane extends TactilePane {
 
         try {
             this.ghci = Optional.of(new GhciSession());
+            this.ghci.get().startAsync();
         } catch (HaskellException e) {
             this.ghci = Optional.empty();
         }
@@ -235,5 +236,23 @@ public class CustomUIPane extends TactilePane {
      */
     public void setCurrentFile(File currentFile) {
         this.currentFile = Optional.of(currentFile);
+    }
+
+    /**
+     * Terminate the current GhciSession, if any, then start a new one.
+     * Waits for the old session to end, but not for the new session to start.
+     */
+    public void restartBackend() {
+        this.ghci.ifPresent(g -> {
+            g.stopAsync();
+            g.awaitTerminated();
+        });
+
+        try {
+            this.ghci = Optional.of(new GhciSession());
+            this.ghci.get().startAsync();
+        } catch (HaskellException e) {
+            this.ghci = Optional.empty();
+        }
     }
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/PreferencesWindow.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/PreferencesWindow.java
@@ -37,18 +37,7 @@ public class PreferencesWindow extends BorderPane implements ComponentLoader {
         ghci.getSelectionModel().select(GhciSession.pickBackend());
         ghci.valueProperty().addListener(x -> {
             preferences.put("ghci", ghci.getValue().toString());
-
-            pane.getGhciSession().ifPresent(ghciSession -> {
-                try {
-                    ghciSession.close();
-                    ghciSession.start();
-                } catch (IOException | HaskellException e) {
-                    // TODO something useful
-                    e.printStackTrace();
-                }
-
-                pane.invalidateAll();
-            });
+            pane.restartBackend();
         });
     }
 

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
@@ -101,11 +101,13 @@ public class DisplayBlock extends Block {
 
                 Futures.addCallback(result, new FutureCallback<String>() {
                     public void onSuccess(String s) {
+                        // Can't call setOutput directly - this may not be JavaFX app thread.
+                        // Instead, schedule setOutput to be done some time in the future.
                         Platform.runLater(() -> setOutput(s));
                     }
 
                     public void onFailure(Throwable throwable) {
-                        Platform.runLater(() -> setOutput("?!?!?!"));
+                        onSuccess("?!?!?!");
                     }
                 });
             }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
@@ -1,6 +1,10 @@
 package nl.utwente.viskell.ui.components;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.fxml.FXML;
@@ -90,14 +94,21 @@ public class DisplayBlock extends Block {
         if (inputAnchor.hasConnection()) {
             this.inputType.setText(this.inputAnchor.getStringType());
 
-            try {
-                Optional<GhciSession> ghci = getPane().getGhciSession();
-                if (ghci.isPresent()) {
-                    setOutput(ghci.get().pull(inputAnchor.getFullExpr()));
-                }
-            } catch (HaskellException e) {
-                setOutput("?!?!?!");
-            } 
+            Optional<GhciSession> ghci = getPane().getGhciSession();
+
+            if (ghci.isPresent()) {
+                ListenableFuture<String> result = ghci.get().pull(inputAnchor.getFullExpr());
+
+                Futures.addCallback(result, new FutureCallback<String>() {
+                    public void onSuccess(String s) {
+                        Platform.runLater(() -> setOutput(s));
+                    }
+
+                    public void onFailure(Throwable throwable) {
+                        Platform.runLater(() -> setOutput("?!?!?!"));
+                    }
+                });
+            }
         } else {
             this.inputType.setText("  ... ");
             setOutput("??");

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Block that accepts a (Float -> Float) function to be displayed on a linechart
@@ -99,7 +100,7 @@ public class GraphBlock extends Block {
             String funName = "graph_fun_" + Integer.toHexString(this.hashCode());
             ghciSession.push(funName, this.getFullExpr());
             String range = String.format(Locale.US, " [%f,%f..%f]", min, min+step, max);
-            String results = ghciSession.pullRaw("putStrLn $ unwords $ map show $ map " + funName + range);
+            String results = ghciSession.pullRaw("putStrLn $ unwords $ map show $ map " + funName + range).get();
 
             LineChart.Series<Double, Double> series = new LineChart.Series<>();
             ObservableList<XYChart.Data<Double, Double>> data = series.getData();
@@ -110,7 +111,7 @@ public class GraphBlock extends Block {
             }
 
             lineChartData.add(series);
-        } catch (HaskellException | NoSuchElementException | NumberFormatException ignored) {
+        } catch (NoSuchElementException | NumberFormatException | InterruptedException | ExecutionException ignored) {
             // Pretend we didn't hear anything.
         }
 

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/RGBBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/RGBBlock.java
@@ -15,6 +15,7 @@ import nl.utwente.viskell.ui.CustomUIPane;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Block with three inputs that represent RGB values.
@@ -54,11 +55,11 @@ public class RGBBlock extends DisplayBlock {
     private int evaluateAnchor(InputAnchor anchor) {
         try {
             GhciSession ghci = getPane().getGhciSession().get();
-            String result = ghci.pull(anchor.getFullExpr());
+            String result = ghci.pull(anchor.getFullExpr()).get();
 
             double v = Math.max(0.0, Math.min(1.0, Double.valueOf(result)));
             return (int) Math.round(v * 255);
-        } catch (NumberFormatException | HaskellException | NoSuchElementException e) {
+        } catch (NumberFormatException | NoSuchElementException | InterruptedException | ExecutionException e) {
             return 0;
         }
     }

--- a/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
+++ b/Code/src/test/java/nl/utwente/viskell/ghcj/GhciSessionTest.java
@@ -4,6 +4,7 @@ import nl.utwente.viskell.haskell.env.Environment;
 import nl.utwente.viskell.haskell.expr.Expression;
 import nl.utwente.viskell.haskell.expr.Value;
 import nl.utwente.viskell.haskell.type.Type;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,9 +20,17 @@ public class GhciSessionTest {
     public void setUp() throws HaskellException {
         this.env = new Environment();
         this.ghci = new GhciSession();
+        this.ghci.startAsync();
+        this.ghci.awaitRunning();
 
         this.env.addTestSignature("my_pi", "Float");
         this.pi = new Value(Type.con("Float"), "3.14");
+    }
+
+    @After
+    public void tearDown() {
+        this.ghci.stopAsync();
+        this.ghci.awaitTerminated();
     }
 
     @Test
@@ -31,8 +40,8 @@ public class GhciSessionTest {
     }
 
     @Test
-    public void constFunPushPull() throws HaskellException {
+    public void constFunPushPull() throws Exception {
         this.ghci.push("my_pi", this.pi);
-        Assert.assertEquals("3.14", this.ghci.pullRaw("my_pi"));
+        Assert.assertEquals("3.14", this.ghci.pullRaw("my_pi").get());
     }
 }


### PR DESCRIPTION
This enables GhciSession to execute Haskell snippets on a different
thread than the main thread.

GhciSession is an AbstractExecutionThreadService from Guava. It takes Haskell
source to execute off the work queue, which is read from a (singular)
execution thread, and filled by anything that wants something executed.

Push and pull methods on GhciSession return 'immediately', and never
throw HaskellException. If (when) something goes wrong, the future will
be set to unsuccesful, which means `get` will throw ExecutionException
or the unsuccesful callback will be called.

DisplayBlock uses callbacks to delay updating of its label until the
future is completed (i.e. evaluation should not block the UI).

RGBBlock and GraphBlock wait for their results for now (i.e. their
behaviour should be unchanged and they will block the UI).