### PR TITLE
Make CustomUIPane's GhciSession not optional

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ghcj/GhciSession.java
+++ b/Code/src/main/java/nl/utwente/viskell/ghcj/GhciSession.java
@@ -41,10 +41,9 @@ public final class GhciSession extends AbstractExecutionThreadService {
     /**
      * Builds a new communication session with ghci.
      *
-     * @throws HaskellException when ghci can not be found, can not be executed,
-     *         or does not understand our setup sequence.
+     * Starting the backend is delayed until startAsync() is called.
      */
-    public GhciSession() throws HaskellException {
+    public GhciSession() {
         super();
 
         queue = new ArrayBlockingQueue<>(1024);

--- a/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/CustomUIPane.java
@@ -24,7 +24,7 @@ public class CustomUIPane extends TactilePane {
     private ObjectProperty<Optional<Block>> selectedBlock;
     private ConnectionCreationManager connectionCreationManager;
     
-    private Optional<GhciSession> ghci;
+    private GhciSession ghci;
     private InspectorWindow inspector;
     private PreferencesWindow preferences;
 
@@ -51,12 +51,8 @@ public class CustomUIPane extends TactilePane {
         this.catalog = catalog;
         this.envInstance = catalog.asEnvironment();
 
-        try {
-            this.ghci = Optional.of(new GhciSession());
-            this.ghci.get().startAsync();
-        } catch (HaskellException e) {
-            this.ghci = Optional.empty();
-        }
+        this.ghci = new GhciSession();
+        this.ghci.startAsync();
 
         this.addEventHandler(MouseEvent.MOUSE_PRESSED, this::handlePress);
         this.addEventHandler(MouseEvent.MOUSE_DRAGGED, this::handleDrag);
@@ -201,7 +197,7 @@ public class CustomUIPane extends TactilePane {
         return connectionCreationManager;
     }
 
-    public Optional<GhciSession> getGhciSession() {
+    public GhciSession getGhciSession() {
         return ghci;
     }
 
@@ -243,16 +239,10 @@ public class CustomUIPane extends TactilePane {
      * Waits for the old session to end, but not for the new session to start.
      */
     public void restartBackend() {
-        this.ghci.ifPresent(g -> {
-            g.stopAsync();
-            g.awaitTerminated();
-        });
+        ghci.stopAsync();
+        ghci.awaitTerminated();
 
-        try {
-            this.ghci = Optional.of(new GhciSession());
-            this.ghci.get().startAsync();
-        } catch (HaskellException e) {
-            this.ghci = Optional.empty();
-        }
+        ghci = new GhciSession();
+        ghci.startAsync();
     }
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
@@ -12,6 +12,7 @@ import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;
 import nl.utwente.viskell.haskell.env.CatalogFunction;
 import nl.utwente.viskell.haskell.env.FunctionInfo;
@@ -145,16 +146,16 @@ public class FunctionMenu extends StackPane implements ComponentLoader {
         Optional<String> result = dialog.showAndWait();
 
         result.ifPresent(value -> {
-            parent.getGhciSession().ifPresent(ghci -> {
-                try {
-                    Type type = ghci.pullType(value, parent.getEnvInstance());
-                    ValueBlock val = new ValueBlock(this.parent, type, value);
-                    addBlock(val);
-                } catch (HaskellException e) {
-                    // Retry.
-                    addValueBlock();
-                }
-            });
+            GhciSession ghci = parent.getGhciSession();
+
+            try {
+                Type type = ghci.pullType(value, parent.getEnvInstance());
+                ValueBlock val = new ValueBlock(this.parent, type, value);
+                addBlock(val);
+            } catch (HaskellException e) {
+                // Retry.
+                addValueBlock();
+            }
         });
     }
 

--- a/Code/src/main/java/nl/utwente/viskell/ui/Main.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/Main.java
@@ -1,5 +1,6 @@
 package nl.utwente.viskell.ui;
 
+import com.google.common.util.concurrent.Service;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
@@ -8,6 +9,7 @@ import javafx.stage.Stage;
 import nl.utwente.ewi.caes.tactilefx.control.TactilePane.EventProcessingMode;
 import nl.utwente.ewi.caes.tactilefx.debug.DebugParent;
 import nl.utwente.viskell.ghcj.GhciEvaluator;
+import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.ghcj.HaskellException;
 import nl.utwente.viskell.haskell.env.HaskellCatalog;
 
@@ -47,10 +49,11 @@ public class Main extends Application {
 
         // Check if GHCI is available
         try {
-            GhciEvaluator testGhci = new GhciEvaluator(); 
-            testGhci.eval("");
-            testGhci.close();
-        } catch (HaskellException e) {
+            GhciSession testGhci = new GhciSession();
+            testGhci.startAsync();
+            testGhci.awaitRunning();
+            testGhci.stopAsync();
+        } catch (RuntimeException e) {
             String msg = "It seems the Glasgow Haskell Compiler, GHC, is not " +
                     "available. Executing programs will not be enabled. We " +
                     "strongly recommend you install GHC, for example by " +
@@ -59,7 +62,7 @@ public class Main extends Application {
 
             e.printStackTrace(); // In case it's not a file-not-found
         }
-        
+
         // Init scene
         Scene scene = new Scene(buttonOverlay);
         scene.getStylesheets().add("/ui/style.css");

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DisplayBlock.java
@@ -94,23 +94,21 @@ public class DisplayBlock extends Block {
         if (inputAnchor.hasConnection()) {
             this.inputType.setText(this.inputAnchor.getStringType());
 
-            Optional<GhciSession> ghci = getPane().getGhciSession();
+            GhciSession ghci = getPane().getGhciSession();
 
-            if (ghci.isPresent()) {
-                ListenableFuture<String> result = ghci.get().pull(inputAnchor.getFullExpr());
+            ListenableFuture<String> result = ghci.pull(inputAnchor.getFullExpr());
 
-                Futures.addCallback(result, new FutureCallback<String>() {
-                    public void onSuccess(String s) {
-                        // Can't call setOutput directly - this may not be JavaFX app thread.
-                        // Instead, schedule setOutput to be done some time in the future.
-                        Platform.runLater(() -> setOutput(s));
-                    }
+            Futures.addCallback(result, new FutureCallback<String>() {
+                public void onSuccess(String s) {
+                    // Can't call setOutput directly - this may not be JavaFX app thread.
+                    // Instead, schedule setOutput to be done some time in the future.
+                    Platform.runLater(() -> setOutput(s));
+                }
 
-                    public void onFailure(Throwable throwable) {
-                        onSuccess("?!?!?!");
-                    }
-                });
-            }
+                public void onFailure(Throwable throwable) {
+                    onSuccess("?!?!?!");
+                }
+            });
         } else {
             this.inputType.setText("  ... ");
             setOutput("??");

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/GraphBlock.java
@@ -96,7 +96,7 @@ public class GraphBlock extends Block {
         double max = x.getUpperBound();
 
         try {
-            GhciSession ghciSession = getPane().getGhciSession().get();
+            GhciSession ghciSession = getPane().getGhciSession();
             String funName = "graph_fun_" + Integer.toHexString(this.hashCode());
             ghciSession.push(funName, this.getFullExpr());
             String range = String.format(Locale.US, " [%f,%f..%f]", min, min+step, max);

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/RGBBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/RGBBlock.java
@@ -54,7 +54,7 @@ public class RGBBlock extends DisplayBlock {
      */
     private int evaluateAnchor(InputAnchor anchor) {
         try {
-            GhciSession ghci = getPane().getGhciSession().get();
+            GhciSession ghci = getPane().getGhciSession();
             String result = ghci.pull(anchor.getFullExpr()).get();
 
             double v = Math.max(0.0, Math.min(1.0, Double.valueOf(result)));


### PR DESCRIPTION
We can always build a GhciSession work queue, even if it doesn't
necessarily answer any requests (say, because ghci is not installed).

Also reworks the 'check if we can use ghci' logic in Main.