### PR TITLE
Add first version of SimulateBlock

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
@@ -144,6 +144,16 @@ public class FunctionMenu extends StackPane implements ComponentLoader {
             utilSpace.getChildren().addAll(sliderBlockButton, rgbBlockButton, graphBlockButton);
         }
 
+        if (GhciSession.pickBackend() == GhciSession.Backend.Clash) {
+            // These blocks are specifically for Clash
+
+            Button simulateBlockButton = new Button("Simulate Block");
+            simulateBlockButton.setOnAction(event -> addBlock(new SimulateBlock(parent)));
+
+            utilSpace.getChildren().addAll(simulateBlockButton);
+        }
+
+
         for (Node button : utilSpace.getChildren()) {
             ((Region) button).setMaxWidth(Double.MAX_VALUE);
         }

--- a/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/FunctionMenu.java
@@ -153,7 +153,6 @@ public class FunctionMenu extends StackPane implements ComponentLoader {
             utilSpace.getChildren().addAll(simulateBlockButton);
         }
 
-
         for (Node button : utilSpace.getChildren()) {
             ((Region) button).setMaxWidth(Double.MAX_VALUE);
         }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
@@ -42,6 +42,9 @@ public class SimulateBlock extends Block implements ComponentLoader {
 
     @FXML protected Button iterationLabel;
 
+    /** Constrained type variable for the input anchor */
+    private final Type funConstraint;
+
     public SimulateBlock(CustomUIPane pane) {
         super(pane);
         loadFXML("SimulateBlock");
@@ -52,6 +55,9 @@ public class SimulateBlock extends Block implements ComponentLoader {
         iteration = new SimpleIntegerProperty(0);
         iteration.addListener(e -> this.invalidateVisualState());
         iteration.addListener(e -> iterationLabel.setText(String.valueOf(iteration.get())));
+
+        String signature = "(Num a, Show b) => Signal a -> Signal b";
+        funConstraint = getPane().getEnvInstance().buildType(signature);
     }
 
     @Override
@@ -101,8 +107,6 @@ public class SimulateBlock extends Block implements ComponentLoader {
 
     @Override
     public void refreshAnchorTypes() {
-        String signature = "(Num a, Show b) => Signal a -> Signal b";
-        Type type = getPane().getEnvInstance().buildType(signature);
-        inputAnchor.setFreshRequiredType(type, new TypeScope());
+        inputAnchor.setFreshRequiredType(funConstraint, new TypeScope());
     }
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
@@ -38,12 +38,13 @@ public class SimulateBlock extends Block implements ComponentLoader {
     /** The label on which to display the value of this block */
     @FXML protected Label value;
 
-    @FXML protected SimpleIntegerProperty iteration;
-
     @FXML protected Button iterationLabel;
 
     /** Constrained type variable for the input anchor */
     private final Type funConstraint;
+
+    /** The number of results to calculate and show */
+    private int iteration;
 
     public SimulateBlock(CustomUIPane pane) {
         super(pane);
@@ -52,9 +53,7 @@ public class SimulateBlock extends Block implements ComponentLoader {
         inputAnchor = new InputAnchor(this);
         inputSpace.getChildren().add(inputAnchor);
 
-        iteration = new SimpleIntegerProperty(0);
-        iteration.addListener(e -> this.invalidateVisualState());
-        iteration.addListener(e -> iterationLabel.setText(String.valueOf(iteration.get())));
+        iteration = 0;
 
         String signature = "(Num a, Show b) => Signal a -> Signal b";
         funConstraint = getPane().getEnvInstance().buildType(signature);
@@ -67,7 +66,7 @@ public class SimulateBlock extends Block implements ComponentLoader {
         if (inputAnchor.hasConnection()) {
             GhciSession ghciSession = getPane().getGhciSession();
             String format = "Data.List.take %d $ simulate (%s) [1..]";
-            String expr = String.format(format, iteration.get(), inputAnchor.getFullExpr().toHaskell());
+            String expr = String.format(format, iteration, inputAnchor.getFullExpr().toHaskell());
             ListenableFuture<String> result = ghciSession.pullRaw(expr);
 
             // See DisplayBlock.invalidateVisualState
@@ -81,13 +80,19 @@ public class SimulateBlock extends Block implements ComponentLoader {
     }
 
     /** Step to the next iteration. */
-    @FXML private void step() {
-        iteration.set(iteration.get() + 1);
+    public void step() {
+        setIteration(iteration + 1);
     }
 
     /** Reset to the first iteration. */
-    @FXML private void reset() {
-        iteration.set(0);
+    public void reset() {
+        setIteration(0);
+    }
+
+    private void setIteration(int i) {
+        iteration = i;
+        iterationLabel.setText(String.valueOf(iteration));
+        this.invalidateVisualState();
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
@@ -1,26 +1,36 @@
 package nl.utwente.viskell.ui.components;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import javafx.application.Platform;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import nl.utwente.viskell.ghcj.GhciSession;
 import nl.utwente.viskell.haskell.expr.Expression;
+import nl.utwente.viskell.haskell.type.Type;
 import nl.utwente.viskell.haskell.type.TypeScope;
 import nl.utwente.viskell.ui.ComponentLoader;
 import nl.utwente.viskell.ui.CustomUIPane;
 
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
+/**
+ * A CLaSH-specific block that is a counterpart to the `simulate` function in Clash. Expects a function that turns a
+ * Signal of monotonically increasing numbers into a Signal of representable result values.
+ *
+ * While signals are infinite, SimulateBlock only shows the first N iterations/steps.
+ */
 public class SimulateBlock extends Block implements ComponentLoader {
     /** The Anchor that is used as input. */
     protected InputAnchor inputAnchor;
 
     /** The space containing the input anchor. */
-    @FXML
-    protected Pane inputSpace;
+    @FXML protected Pane inputSpace;
 
     /** The label on which to display type information. */
     @FXML protected Label inputType;
@@ -28,9 +38,9 @@ public class SimulateBlock extends Block implements ComponentLoader {
     /** The label on which to display the value of this block */
     @FXML protected Label value;
 
-    @FXML private SimpleIntegerProperty iteration;
+    @FXML protected SimpleIntegerProperty iteration;
 
-    @FXML protected Label iterationLabel;
+    @FXML protected Button iterationLabel;
 
     public SimulateBlock(CustomUIPane pane) {
         super(pane);
@@ -41,32 +51,35 @@ public class SimulateBlock extends Block implements ComponentLoader {
 
         iteration = new SimpleIntegerProperty(0);
         iteration.addListener(e -> this.invalidateVisualState());
-        iteration.addListener(e -> this.iterationLabel.setText(String.valueOf(iteration.get())));
+        iteration.addListener(e -> iterationLabel.setText(String.valueOf(iteration.get())));
     }
 
     @Override
     public final void invalidateVisualState() {
-        this.inputType.setText(this.inputAnchor.getStringType());
+        inputType.setText(inputAnchor.getStringType());
 
         if (inputAnchor.hasConnection()) {
-            try {
-                GhciSession ghciSession = getPane().getGhciSession();
-                String funName = "sim_fun_" + Integer.toHexString(this.hashCode());
-                ghciSession.push(funName, inputAnchor.getFullExpr());
-                String results = ghciSession.pullRaw("Data.List.take " + iteration.get() + " $ simulate " + funName + " [1..]").get();
-                value.setText(results);
-            } catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
-            }
+            GhciSession ghciSession = getPane().getGhciSession();
+            String format = "Data.List.take %d $ simulate (%s) [1..]";
+            String expr = String.format(format, iteration.get(), inputAnchor.getFullExpr().toHaskell());
+            ListenableFuture<String> result = ghciSession.pullRaw(expr);
+
+            // See DisplayBlock.invalidateVisualState
+            Futures.addCallback(result, new FutureCallback<String>() {
+                public void onSuccess(String s)    { Platform.runLater(() -> value.setText(s)); }
+                public void onFailure(Throwable t) { Platform.runLater(() -> value.setText("?!?!?!")); }
+            });
         } else {
             value.setText("?");
         }
     }
 
+    /** Step to the next iteration. */
     @FXML private void step() {
         iteration.set(iteration.get() + 1);
     }
 
+    /** Reset to the first iteration. */
     @FXML private void reset() {
         iteration.set(0);
     }
@@ -88,6 +101,8 @@ public class SimulateBlock extends Block implements ComponentLoader {
 
     @Override
     public void refreshAnchorTypes() {
-        this.inputAnchor.setFreshRequiredType(getPane().getEnvInstance().buildType("Signal a -> Signal b"), new TypeScope());
+        String signature = "(Num a, Show b) => Signal a -> Signal b";
+        Type type = getPane().getEnvInstance().buildType(signature);
+        inputAnchor.setFreshRequiredType(type, new TypeScope());
     }
 }

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/SimulateBlock.java
@@ -1,0 +1,93 @@
+package nl.utwente.viskell.ui.components;
+
+import com.google.common.collect.ImmutableList;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
+import nl.utwente.viskell.ghcj.GhciSession;
+import nl.utwente.viskell.haskell.expr.Expression;
+import nl.utwente.viskell.haskell.type.TypeScope;
+import nl.utwente.viskell.ui.ComponentLoader;
+import nl.utwente.viskell.ui.CustomUIPane;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class SimulateBlock extends Block implements ComponentLoader {
+    /** The Anchor that is used as input. */
+    protected InputAnchor inputAnchor;
+
+    /** The space containing the input anchor. */
+    @FXML
+    protected Pane inputSpace;
+
+    /** The label on which to display type information. */
+    @FXML protected Label inputType;
+
+    /** The label on which to display the value of this block */
+    @FXML protected Label value;
+
+    @FXML private SimpleIntegerProperty iteration;
+
+    @FXML protected Label iterationLabel;
+
+    public SimulateBlock(CustomUIPane pane) {
+        super(pane);
+        loadFXML("SimulateBlock");
+
+        inputAnchor = new InputAnchor(this);
+        inputSpace.getChildren().add(inputAnchor);
+
+        iteration = new SimpleIntegerProperty(0);
+        iteration.addListener(e -> this.invalidateVisualState());
+        iteration.addListener(e -> this.iterationLabel.setText(String.valueOf(iteration.get())));
+    }
+
+    @Override
+    public final void invalidateVisualState() {
+        this.inputType.setText(this.inputAnchor.getStringType());
+
+        if (inputAnchor.hasConnection()) {
+            try {
+                GhciSession ghciSession = getPane().getGhciSession();
+                String funName = "sim_fun_" + Integer.toHexString(this.hashCode());
+                ghciSession.push(funName, inputAnchor.getFullExpr());
+                String results = ghciSession.pullRaw("Data.List.take " + iteration.get() + " $ simulate " + funName + " [1..]").get();
+                value.setText(results);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            value.setText("?");
+        }
+    }
+
+    @FXML private void step() {
+        iteration.set(iteration.get() + 1);
+    }
+
+    @FXML private void reset() {
+        iteration.set(0);
+    }
+
+    @Override
+    public List<InputAnchor> getAllInputs() {
+        return ImmutableList.of(inputAnchor);
+    }
+
+    @Override
+    public List<OutputAnchor> getAllOutputs() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Expression getLocalExpr() {
+        return inputAnchor.getLocalExpr();
+    }
+
+    @Override
+    public void refreshAnchorTypes() {
+        this.inputAnchor.setFreshRequiredType(getPane().getEnvInstance().buildType("Signal a -> Signal b"), new TypeScope());
+    }
+}

--- a/Code/src/main/resources/catalog/clash.xml
+++ b/Code/src/main/resources/catalog/clash.xml
@@ -223,5 +223,32 @@
         <category name="Simulation">
             <function name="simulate" signature="(Signal a -> Signal b) -> [a] -> [b]"/>
         </category>
+        <category name="Utility functions">
+            <function name="id" signature="a -> a">
+                identity function.
+            </function>
+            <function name="const" signature="a -> b -> a">
+                constant function.
+            </function>
+            <function name="(.)" signature="(b -> c) -> (a -> b) -> a -> c">
+                Function composition
+            </function>
+            <function name="flip" signature="(a -> b -> c) -> b -> a -> c">
+                flip f takes its (first) two arguments in the reverse order of f.
+            </function>
+            <function name="($)" signature="(a -> b) -> a -> b">
+                Application operator. This operator is used to apply user defined functions, since ordinary application (f x) means
+                the same as (f $ x). However, $ has low, right-associative binding precedence, so it
+                sometimes allows parentheses to be omitted.
+            </function>
+            <function name="undefined" signature="a">
+                A special case of error. It is expected that compilers will recognize this and insert error
+                messages which are more appropriate to the context in which undefined appears.
+            </function>
+            <function name="seq" signature="a -> b -> b">
+                The value of seq a b is bottom if a is bottom, and otherwise equal to b. seq is usually
+                introduced to improve performance by avoiding unneeded laziness.
+            </function>
+        </category>
     </functions>
 </catalog>

--- a/Code/src/main/resources/ui/SimulateBlock.fxml
+++ b/Code/src/main/resources/ui/SimulateBlock.fxml
@@ -6,18 +6,13 @@
     <BorderPane styleClass="display, block">
         <center>
             <VBox alignment="CENTER">
-                <!-- silly extra HBox to not break the argumentSpace css -->
-                <HBox styleClass="argumentSpace">
-                    <Label fx:id="inputType"/>
+                <Label fx:id="inputType" styleClass="argumentLabel" />
+                <Label fx:id="value" styleClass="content"/>
+                <HBox alignment="CENTER">
+                    <Button styleClass="subtle" fx:id="iterationLabel" onAction="#invalidateVisualState">0</Button>
+                    <Button styleClass="subtle" fx:id="step" onAction="#step">Step</Button>
+                    <Button styleClass="subtle" fx:id="restart" onAction="#reset">Reset</Button>
                 </HBox>
-                <VBox>
-                    <Label fx:id="value" styleClass="content"/>
-                    <HBox alignment="CENTER">
-                        <Button styleClass="subtle" fx:id="iterationLabel" onAction="#invalidateVisualState">0</Button>
-                        <Button styleClass="subtle" fx:id="step" onAction="#step">Step</Button>
-                        <Button styleClass="subtle" fx:id="restart" onAction="#reset">Reset</Button>
-                    </HBox>
-                </VBox>
             </VBox>
         </center>
         <top>

--- a/Code/src/main/resources/ui/SimulateBlock.fxml
+++ b/Code/src/main/resources/ui/SimulateBlock.fxml
@@ -13,9 +13,9 @@
                 <VBox>
                     <Label fx:id="value" styleClass="content"/>
                     <HBox alignment="CENTER">
-                        <Label styleClass="subtle" fx:id="iterationLabel">0</Label>
+                        <Button styleClass="subtle" fx:id="iterationLabel" onAction="#invalidateVisualState">0</Button>
                         <Button styleClass="subtle" fx:id="step" onAction="#step">Step</Button>
-                        <Button styleClass="subtle" fx:id="restart" onAction="#reset">Restart</Button>
+                        <Button styleClass="subtle" fx:id="restart" onAction="#reset">Reset</Button>
                     </HBox>
                 </VBox>
             </VBox>

--- a/Code/src/main/resources/ui/SimulateBlock.fxml
+++ b/Code/src/main/resources/ui/SimulateBlock.fxml
@@ -1,0 +1,27 @@
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.*?>
+<?import nl.utwente.viskell.ui.components.SimulateBlock?>
+<?import javafx.scene.control.Button?>
+<fx:root type="nl.utwente.viskell.ui.components.SimulateBlock" xmlns:fx="http://javafx.com/fxml/">
+    <BorderPane styleClass="display, block">
+        <center>
+            <VBox alignment="CENTER">
+                <!-- silly extra HBox to not break the argumentSpace css -->
+                <HBox styleClass="argumentSpace">
+                    <Label fx:id="inputType"/>
+                </HBox>
+                <VBox>
+                    <Label fx:id="value" styleClass="content"/>
+                    <HBox alignment="CENTER">
+                        <Label styleClass="subtle" fx:id="iterationLabel">0</Label>
+                        <Button styleClass="subtle" fx:id="step" onAction="#step">Step</Button>
+                        <Button styleClass="subtle" fx:id="restart" onAction="#reset">Restart</Button>
+                    </HBox>
+                </VBox>
+            </VBox>
+        </center>
+        <top>
+            <HBox fx:id="inputSpace"/>
+        </top>
+    </BorderPane>
+</fx:root>

--- a/Code/src/main/resources/ui/colours.css
+++ b/Code/src/main/resources/ui/colours.css
@@ -98,7 +98,7 @@ MatchBlock.selected {
     -fx-background-color: #C8B6C5;
 }
 
-.argumentSpace Label {
+.argumentSpace Label, .argumentLabel {
     -fx-text-fill: black;
     -fx-background-color: white;
 }

--- a/Code/src/main/resources/ui/layout.css
+++ b/Code/src/main/resources/ui/layout.css
@@ -75,7 +75,7 @@ SliderBlock .value.block {
     -fx-alignment: center;
 }
 
-.argumentSpace Label {
+.argumentSpace Label, .argumentLabel {
     -fx-padding: 0 5 0 5;
     -fx-font-size: 14px;
     -fx-font-weight: normal;

--- a/Code/src/main/resources/ui/layout.css
+++ b/Code/src/main/resources/ui/layout.css
@@ -107,3 +107,10 @@ Connection {
     -fx-background-insets: 0, 0;
     -fx-background-radius: 0, 0;
 }
+
+.subtle {
+    -fx-background-color: rgba(0, 0, 0, 0);
+    -fx-font-size: 12px;
+    -fx-font-weight: bold;
+    -fx-text-fill: white;
+}


### PR DESCRIPTION
> SimulateBlock is CLaSH-specific block that is a counterpart to the `simulate`
> function in Clash. Expects a function that turns a Signal of monotonically
> increasing numbers into a Signal of representable result values.
> 
> While signals are infinite, SimulateBlock only shows the first N
> iterations/steps.

It's basically a poor man's (stepping) debugger.