### PR TITLE
Log the last sixteen Haskell runtime errors

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/InspectorWindow.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/InspectorWindow.java
@@ -2,6 +2,7 @@ package nl.utwente.viskell.ui;
 
 import javafx.fxml.FXML;
 import javafx.scene.Scene;
+import javafx.scene.control.ListView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
@@ -21,6 +22,7 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
     private CustomUIPane pane;
 
     @FXML private TreeView<String> tree;
+    @FXML private ListView<String> errors;
     @FXML private TextArea hs;
     @FXML private TextArea json;
 
@@ -68,6 +70,7 @@ public class InspectorWindow extends BorderPane implements ComponentLoader {
 
         tree.setRoot(root);
         hs.setText(haskell.toString());
+        errors.getItems().setAll(pane.getGhciSession().getErrors());
     }
 
     /**

--- a/Code/src/main/resources/ui/InspectorWindow.fxml
+++ b/Code/src/main/resources/ui/InspectorWindow.fxml
@@ -5,14 +5,17 @@
 <fx:root type="nl.utwente.viskell.ui.InspectorWindow" xmlns:fx="http://javafx.com/fxml/">
     <center>
         <TabPane>
-            <Tab closable="false" text="Expression tree">
+            <Tab closable="false" text="Tree">
                 <TreeView fx:id="tree" />
             </Tab>
-            <Tab closable="false" text="Haskell source">
+            <Tab closable="false" text="Source">
                 <TextArea fx:id="hs" />
             </Tab>
-            <Tab closable="false" text="JSON serialization">
+            <Tab closable="false" text="JSON">
                 <TextArea fx:id="json" />
+            </Tab>
+            <Tab closable="false" text="Errors">
+                <ListView fx:id="errors" />
             </Tab>
         </TabPane>
     </center>


### PR DESCRIPTION
This has the GhciSession log the last LOG_SIZE (16) error descriptions
from Ghci. They are only shown in the InspectorWindow for now.