### PR TITLE
Fix two small bugs

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ghcj/ClashEvaluator.java
+++ b/Code/src/main/java/nl/utwente/viskell/ghcj/ClashEvaluator.java
@@ -15,7 +15,7 @@ public class ClashEvaluator extends GhciEvaluator {
 
     @Override
     protected List<String> getCommand() {
-        return ImmutableList.of("clash", "--interactive", "-ignore-dot-ghci");
+        return ImmutableList.of("clash", "--interactive", "-ignore-dot-ghci", "-fno-warn-overlapping-patterns");
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ghcj/GhciEvaluator.java
+++ b/Code/src/main/java/nl/utwente/viskell/ghcj/GhciEvaluator.java
@@ -15,7 +15,7 @@ public class GhciEvaluator extends Evaluator {
 
     @Override
     protected List<String> getCommand() {
-        return ImmutableList.of("ghci", "-ignore-dot-ghci");
+        return ImmutableList.of("ghci", "-ignore-dot-ghci", "-fno-warn-overlapping-patterns");
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/LambdaContainer.java
@@ -195,7 +195,7 @@ public class LambdaContainer extends BorderPane implements ComponentLoader, Wrap
     public void deleteAllLinks() {
        this.args.forEach(OutputAnchor::removeConnections);
        this.res.removeConnections();
-       this.attachedBlocks.forEach(block -> block.moveIntoContainer(this.getParentContainer()));
+       new ArrayList<>(this.attachedBlocks).forEach(block -> block.moveIntoContainer(this.getParentContainer()));
     }
 
     @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/Lane.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/Lane.java
@@ -221,6 +221,6 @@ public class Lane extends BorderPane implements WrappedContainer, ComponentLoade
     public void deleteAllLinks() {
         this.arguments.forEach(OutputAnchor::removeConnections);
         this.result.removeConnections();
-        this.attachedBlocks.forEach(block -> block.moveIntoContainer(this.getParentContainer()));
+        new ArrayList<>(this.attachedBlocks).forEach(block -> block.moveIntoContainer(this.getParentContainer()));
     }
 }


### PR DESCRIPTION
One is avoiding a concurrent modifications exceptions on deleting a lambda or case.
Second is stopping a warning from breaking evaluator value parsing.