### PR TITLE
Use the actual area of blocks for the clickable region

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/components/BinOpApplyBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/BinOpApplyBlock.java
@@ -77,6 +77,7 @@ public class BinOpApplyBlock extends Block {
             this.anchor.layoutXProperty().bind(this.inputType.widthProperty().divide(2));
             this.getChildren().addAll(this.anchor, this.typePane);
             this.setTranslateY(-9);
+            this.setPickOnBounds(false);
 
             dragContext = new DragContext(this.typePane);
             dragContext.setDragInitAction(c -> {this.curried = false;});
@@ -163,6 +164,7 @@ public class BinOpApplyBlock extends Block {
         this.resTypeLabel.getStyleClass().add("resultType");
         VBox outputSpace = new VBox(this.resTypeLabel, this.output);
         outputSpace.setAlignment(Pos.CENTER);
+        outputSpace.setPickOnBounds(false);
         
         this.leftInput = new FunInputAnchor();
         this.rightInput = new FunInputAnchor();
@@ -172,6 +174,7 @@ public class BinOpApplyBlock extends Block {
         arrowSpacer.getStyleClass().add("curryArrow");
         arrowSpacer.setVisible(false);
         Pane inputSpace = new HBox(0, this.leftInput, infoArea, arrowSpacer, this.rightInput);
+        inputSpace.setPickOnBounds(false);
 
         this.curriedOutput = new Pane() {
                 @Override

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/Block.java
@@ -64,6 +64,9 @@ public abstract class Block extends StackPane implements Bundleable, ComponentLo
         this.container = pane;
         this.container.attachBlock(this);
         
+        // only the actual shape should be selected for events, not the larger outside bounds
+        this.setPickOnBounds(false);
+        
         if (!this.belongsOnBottom()) {
             // make all non container blocks resize themselves around horizontal midpoint to reduce visual movement 
             this.translateXProperty().bind(this.widthProperty().divide(2).negate());

--- a/Code/src/main/java/nl/utwente/viskell/ui/components/FunApplyBlock.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/FunApplyBlock.java
@@ -79,6 +79,7 @@ public class FunApplyBlock extends Block {
             this.anchor.layoutXProperty().bind(this.inputType.widthProperty().divide(2));
             this.getChildren().addAll(this.anchor, this.typePane);
             this.setTranslateY(-9);
+            this.setPickOnBounds(false);
 
             dragContext = new DragContext(this.typePane);
             dragContext.setDragInitAction(c -> {this.curried = false;});
@@ -158,6 +159,7 @@ public class FunApplyBlock extends Block {
         this.resTypeLabel.getStyleClass().add("resultType");
         VBox outputSpace = new VBox(this.resTypeLabel, this.output);
         outputSpace.setAlignment(Pos.CENTER);
+        outputSpace.setPickOnBounds(false);
         
         Type t = funInfo.getFreshSignature();
         while (t instanceof FunType) {
@@ -169,6 +171,8 @@ public class FunApplyBlock extends Block {
         Iterables.getLast(FunApplyBlock.this.inputs).curryArrow.setManaged(false);
 
         Pane inputSpace = new HBox(0, this.inputs.toArray(new Node[this.inputs.size()]));
+        inputSpace.setPickOnBounds(false);
+        
         this.curriedOutput = new Pane() {
                 @Override
                 public double computePrefWidth(double height) {

--- a/Code/src/main/resources/ui/ArgumentSpace.fxml
+++ b/Code/src/main/resources/ui/ArgumentSpace.fxml
@@ -1,7 +1,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.shape.Circle?>
 <?import nl.utwente.viskell.ui.components.ArgumentSpace?>
-<fx:root type="nl.utwente.viskell.ui.components.ArgumentSpace" xmlns:fx="http://javafx.com/fxml/1" styleClass="argumentSpace">
+<fx:root type="nl.utwente.viskell.ui.components.ArgumentSpace" xmlns:fx="http://javafx.com/fxml/1" styleClass="argumentSpace" pickOnBounds="false">
     <Circle fx:id="knot" radius="10"/>
     <Label fx:id="rightArgument" styleClass="rightArgument"/>
 </fx:root>

--- a/Code/src/main/resources/ui/BinOpApplyBlock.fxml
+++ b/Code/src/main/resources/ui/BinOpApplyBlock.fxml
@@ -2,10 +2,10 @@
 <?import javafx.geometry.Insets?>
 <?import nl.utwente.viskell.ui.components.BinOpApplyBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.BinOpApplyBlock" xmlns:fx="http://javafx.com/fxml/1">
-	<HBox styleClass="function, block">
+	<HBox styleClass="function, block" pickOnBounds="false">
 		<padding>
 			<Insets bottom="0" left="5" right="5" top="0" />
 		</padding>
-    	<Pane fx:id="bodySpace"/>
+    	<Pane fx:id="bodySpace" pickOnBounds="false"/>
     </HBox>
 </fx:root>

--- a/Code/src/main/resources/ui/ChoiceBlock.fxml
+++ b/Code/src/main/resources/ui/ChoiceBlock.fxml
@@ -2,8 +2,8 @@
 <?import javafx.scene.layout.*?>
 <?import nl.utwente.viskell.ui.components.ChoiceBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.ChoiceBlock" xmlns:fx="http://javafx.com/fxml/">
-    <VBox styleClass="def">
+    <VBox styleClass="def" pickOnBounds="false">
     	<HBox fx:id="altSpace"/>
-        <HBox fx:id="resultSpace" spacing="50" alignment="BOTTOM_CENTER"/>
+        <HBox fx:id="resultSpace" spacing="50" alignment="BOTTOM_CENTER" pickOnBounds="false" />
     </VBox>
 </fx:root>

--- a/Code/src/main/resources/ui/DefinitionBlock.fxml
+++ b/Code/src/main/resources/ui/DefinitionBlock.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.layout.*?>
 <?import nl.utwente.viskell.ui.components.DefinitionBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.DefinitionBlock" xmlns:fx="http://javafx.com/fxml/">
-    <VBox>
+    <VBox pickOnBounds="false">
     	<Pane styleClass="lambdaBorder">
         	<Label text="Spacer" styleClass="inputType" visible="false"/>
        	</Pane>
@@ -11,6 +11,6 @@
        	<Pane styleClass="lambdaBorder">
        		<Label fx:id="signature" styleClass="inputType" />
        	</Pane>	
-		<HBox fx:id="funSpace" translateX="20" alignment="BOTTOM_LEFT"/>
+		<HBox fx:id="funSpace" translateX="20" alignment="BOTTOM_LEFT" pickOnBounds="false"/>
     </VBox>
 </fx:root>

--- a/Code/src/main/resources/ui/DisplayBlock.fxml
+++ b/Code/src/main/resources/ui/DisplayBlock.fxml
@@ -2,12 +2,12 @@
 <?import javafx.scene.layout.*?>
 <?import nl.utwente.viskell.ui.components.DisplayBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.DisplayBlock" xmlns:fx="http://javafx.com/fxml/">
-    <BorderPane styleClass="display, block">
+    <BorderPane styleClass="display, block" pickOnBounds="false">
         <center>
             <Label fx:id="value" styleClass="content" maxWidth="300" alignment="CENTER"/>
         </center>
         <top>
-        	<VBox fx:id="inputSpace">
+        	<VBox fx:id="inputSpace" pickOnBounds="false">
         	    <Label fx:id="inputType" styleClass="inputType"/>
         	</VBox>
         </top>

--- a/Code/src/main/resources/ui/FunApplyBlock.fxml
+++ b/Code/src/main/resources/ui/FunApplyBlock.fxml
@@ -3,11 +3,11 @@
 <?import javafx.geometry.Insets?>
 <?import nl.utwente.viskell.ui.components.FunApplyBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.FunApplyBlock" xmlns:fx="http://javafx.com/fxml/1">
-    <HBox styleClass="function, block">
+    <HBox styleClass="function, block" pickOnBounds="false">
 		<padding>
 			<Insets bottom="0" left="5" right="5" top="0" />
 		</padding>
     	<Label fx:id="functionInfo" styleClass="title" />
-		<Pane fx:id="bodySpace" />
+		<Pane fx:id="bodySpace" pickOnBounds="false" />
     </HBox>
 </fx:root>

--- a/Code/src/main/resources/ui/FunctionBlock.fxml
+++ b/Code/src/main/resources/ui/FunctionBlock.fxml
@@ -2,18 +2,18 @@
 <?import javafx.scene.layout.*?>
 <?import nl.utwente.viskell.ui.components.FunctionBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.FunctionBlock" xmlns:fx="http://javafx.com/fxml/1">
-    <BorderPane>
+    <BorderPane pickOnBounds="false">
         <center>
-            <HBox styleClass="function, block">
+            <HBox styleClass="function, block" pickOnBounds="false">
                 <Label fx:id="functionInfo" styleClass="title" />
-                <Pane fx:id="nestSpace"/>
+                <Pane fx:id="nestSpace" pickOnBounds="false" />
             </HBox>
         </center>
         <top>
-            <TilePane fx:id="inputSpace"/>
+            <TilePane fx:id="inputSpace" pickOnBounds="false" />
         </top>
         <bottom>
-            <HBox fx:id="outputSpace"/>
+            <HBox fx:id="outputSpace" pickOnBounds="false" />
         </bottom>
     </BorderPane>
 </fx:root>

--- a/Code/src/main/resources/ui/GraphBlock.fxml
+++ b/Code/src/main/resources/ui/GraphBlock.fxml
@@ -4,9 +4,9 @@
 <?import javafx.scene.layout.Pane?>
 <?import nl.utwente.viskell.ui.components.GraphBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.GraphBlock" xmlns:fx="http://javafx.com/fxml/">
-    <BorderPane styleClass="graph, block">
+    <BorderPane styleClass="graph, block" pickOnBounds="false">
         <top>
-            <Pane fx:id="inputSpace" maxHeight="0"/>
+            <Pane fx:id="inputSpace" maxHeight="0" pickOnBounds="false" />
         </top>
         <center>
             <LineChart  prefWidth="500" prefHeight="300" fx:id="chart" createSymbols="false" legendVisible="false" animated="false">

--- a/Code/src/main/resources/ui/MatchBlock.fxml
+++ b/Code/src/main/resources/ui/MatchBlock.fxml
@@ -3,17 +3,17 @@
 <?import javafx.geometry.Insets?>
 <?import nl.utwente.viskell.ui.components.MatchBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.MatchBlock"    xmlns:fx="http://javafx.com/fxml/">
-    <BorderPane>
+    <BorderPane pickOnBounds="false">
         <center>
             <HBox styleClass="match, block">
                 <Label fx:id="name" styleClass="title" />
             </HBox>
         </center>
         <top>
-            <HBox fx:id="inputSpace"/>
+            <HBox fx:id="inputSpace" pickOnBounds="false" />
         </top>
         <bottom>
-            <HBox fx:id="outputSpace" spacing="50">
+            <HBox fx:id="outputSpace" spacing="50" pickOnBounds="false">
                 <padding>
                     <Insets bottom="0" left="20" right="20" top="0" />
                 </padding>

--- a/Code/src/main/resources/ui/SimulateBlock.fxml
+++ b/Code/src/main/resources/ui/SimulateBlock.fxml
@@ -3,7 +3,7 @@
 <?import nl.utwente.viskell.ui.components.SimulateBlock?>
 <?import javafx.scene.control.Button?>
 <fx:root type="nl.utwente.viskell.ui.components.SimulateBlock" xmlns:fx="http://javafx.com/fxml/">
-    <BorderPane styleClass="display, block">
+    <BorderPane styleClass="display, block" pickOnBounds="false">
         <center>
             <VBox alignment="CENTER">
                 <Label fx:id="inputType" styleClass="argumentLabel" />
@@ -16,7 +16,7 @@
             </VBox>
         </center>
         <top>
-            <HBox fx:id="inputSpace"/>
+            <HBox fx:id="inputSpace" pickOnBounds="false" />
         </top>
     </BorderPane>
 </fx:root>

--- a/Code/src/main/resources/ui/SliderBlock.fxml
+++ b/Code/src/main/resources/ui/SliderBlock.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.layout.*?>
 <?import nl.utwente.viskell.ui.components.SliderBlock?>
 <fx:root type="nl.utwente.viskell.ui.components.SliderBlock" xmlns:fx="http://javafx.com/fxml/">
-    <BorderPane styleClass="value, block">
+    <BorderPane styleClass="value, block" pickOnBounds="false">
         <center>
             <VBox alignment="CENTER">
                 <Slider min="-1.0" max="1.0" fx:id="slider"/>
@@ -11,7 +11,7 @@
             </VBox>
         </center>
         <bottom>
-            <VBox fx:id="outputSpace">
+            <VBox fx:id="outputSpace" pickOnBounds="false">
             	<Label fx:id="valueType" styleClass="inputType"/>
             </VBox>
         </bottom>


### PR DESCRIPTION
By default panes use their outside bounds to determine whether they are the target of a click, but for blocks with all these anchors sticking out those bounds are too large.