### PR TITLE
Do not allow wires connect an input with an output of the same block

### DIFF
--- a/Code/src/main/java/nl/utwente/viskell/ui/components/DrawWire.java
+++ b/Code/src/main/java/nl/utwente/viskell/ui/components/DrawWire.java
@@ -149,6 +149,11 @@ public class DrawWire extends CubicCurve implements ChangeListener<Transform>, C
             }
         }
 
+        if (sink.block == source.block && !(sink instanceof ResultAnchor)) {
+            // self recursive wires are not allowed
+            return null;
+        }
+        
         return new Connection(source, sink);
     }
 


### PR DESCRIPTION
It was too easy to accidentally connect a block with itself, with obvious bad effects.