### PR TITLE
Show type on unshowable inputs of a displayblock

### DIFF
--- a/Code/src/main/resources/ui/DisplayBlock.fxml
+++ b/Code/src/main/resources/ui/DisplayBlock.fxml
@@ -7,9 +7,7 @@
             <Label fx:id="value" styleClass="content" maxWidth="300" alignment="CENTER"/>
         </center>
         <top>
-        	<VBox fx:id="inputSpace" pickOnBounds="false">
-        	    <Label fx:id="inputType" styleClass="inputType"/>
-        	</VBox>
+        	<VBox fx:id="inputSpace" pickOnBounds="false"/>
         </top>
     </BorderPane>
 </fx:root>


### PR DESCRIPTION
Also dropped show constraint, which only causes typelabels to be bigger everywhere.